### PR TITLE
Inner Product

### DIFF
--- a/src/inner.rs
+++ b/src/inner.rs
@@ -1,18 +1,26 @@
 use crate::types::*;
 use ndarray::*;
 
-pub trait Inner<S: Data> {
-    /// Inner product `(self.conjugate, rhs)`
-    fn inner(&self, rhs: &ArrayBase<S, Ix1>) -> S::Elem;
+/// Inner Product
+///
+/// Differenct from `Dot` trait, this take complex conjugate of `self` elements
+///
+pub trait InnerProduct {
+    type Elem: Scalar;
+
+    /// Inner product `(self.conjugate, rhs)
+    fn inner<S>(&self, rhs: &ArrayBase<S, Ix1>) -> Self::Elem
+    where
+        S: Data<Elem = Self::Elem>;
 }
 
-impl<A, S1, S2> Inner<S1> for ArrayBase<S2, Ix1>
+impl<A, S> InnerProduct for ArrayBase<S, Ix1>
 where
     A: Scalar,
-    S1: Data<Elem = A>,
-    S2: Data<Elem = A>,
+    S: Data<Elem = A>,
 {
-    fn inner(&self, rhs: &ArrayBase<S1, Ix1>) -> A {
+    type Elem = A;
+    fn inner<St: Data<Elem = A>>(&self, rhs: &ArrayBase<St, Ix1>) -> A {
         Zip::from(self)
             .and(rhs)
             .fold_while(A::zero(), |acc, s, r| FoldWhile::Continue(acc + s.conj() * *r))

--- a/src/inner.rs
+++ b/src/inner.rs
@@ -21,6 +21,7 @@ where
 {
     type Elem = A;
     fn inner<St: Data<Elem = A>>(&self, rhs: &ArrayBase<St, Ix1>) -> A {
+        assert_eq!(self.len(), rhs.len());
         Zip::from(self)
             .and(rhs)
             .fold_while(A::zero(), |acc, s, r| FoldWhile::Continue(acc + s.conj() * *r))

--- a/src/inner.rs
+++ b/src/inner.rs
@@ -1,0 +1,21 @@
+use crate::types::*;
+use ndarray::*;
+
+pub trait Inner<S: Data> {
+    /// Inner product `(self.conjugate, rhs)`
+    fn inner(&self, rhs: &ArrayBase<S, Ix1>) -> S::Elem;
+}
+
+impl<A, S1, S2> Inner<S1> for ArrayBase<S2, Ix1>
+where
+    A: Scalar,
+    S1: Data<Elem = A>,
+    S2: Data<Elem = A>,
+{
+    fn inner(&self, rhs: &ArrayBase<S1, Ix1>) -> A {
+        Zip::from(self)
+            .and(rhs)
+            .fold_while(A::zero(), |acc, s, r| FoldWhile::Continue(acc + s.conj() * *r))
+            .into_inner()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,7 @@ pub mod diagonal;
 pub mod eigh;
 pub mod error;
 pub mod generate;
+pub mod inner;
 pub mod lapack;
 pub mod layout;
 pub mod norm;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,7 @@ pub use convert::*;
 pub use diagonal::*;
 pub use eigh::*;
 pub use generate::*;
+pub use inner::*;
 pub use layout::*;
 pub use norm::*;
 pub use operator::*;

--- a/tests/inner.rs
+++ b/tests/inner.rs
@@ -1,0 +1,26 @@
+use ndarray::*;
+use ndarray_linalg::*;
+
+#[should_panic]
+#[test]
+fn size_shoter() {
+    let a: Array1<f32> = Array::zeros(3);
+    let b = Array::zeros(4);
+    a.inner(&b);
+}
+
+#[should_panic]
+#[test]
+fn size_longer() {
+    let a: Array1<f32> = Array::zeros(3);
+    let b = Array::zeros(4);
+    b.inner(&a);
+}
+
+#[test]
+fn abs() {
+    let a: Array1<c32> = random(1);
+    let aa = a.inner(&a);
+    assert_aclose!(aa.re(), a.norm().powi(2), 1e-5);
+    assert_aclose!(aa.im(), 0.0, 1e-5);
+}


### PR DESCRIPTION
Calculate inner product of two arrays `(a, b) = a† b`.
Different from `Dot` in ndarray crate, this take Hermite conjugate of prior array (`a` in this case).