### PR TITLE
Make blas/lapack-src non-optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,9 +34,7 @@ default-features = false
 [dependencies.blas-src]
 version = "0.3"
 default-features = false
-optional = true
 
 [dependencies.lapack-src]
 version = "0.3"
 default-features = false
-optional = true


### PR DESCRIPTION
Build of document fails https://docs.rs/crate/ndarray-linalg/0.11.0