### PR TITLE
Linear regression example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,3 +50,5 @@ optional = true
 [dev-dependencies]
 paste = "0.1"
 ndarray-stats = {git = "https://github.com/rust-ndarray/ndarray-stats", branch = "master"}
+ndarray-rand = "0.9"
+rand = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,3 +49,4 @@ optional = true
 
 [dev-dependencies]
 paste = "0.1"
+ndarray-stats = {git = "https://github.com/rust-ndarray/ndarray-stats", branch = "master"}

--- a/examples/linear_regression.rs
+++ b/examples/linear_regression.rs
@@ -77,7 +77,7 @@ fn get_data(n_samples: usize, n_features: usize) -> (
     let shape = (n_samples, n_features);
     let noise: Array1<f64> = Array::random(n_samples, StandardNormal);
 
-    let beta: Array1<f64> = random(n_features) * 100.;
+    let beta: Array1<f64> = random(n_features) * 10.;
     println!("Beta used to generate target variable: {:.3}", beta);
 
     let X: Array2<f64> = random(shape);

--- a/examples/linear_regression.rs
+++ b/examples/linear_regression.rs
@@ -72,7 +72,7 @@ impl LinearRegression {
         if self.fit_intercept {
             let dummy_column: Array<f64, _> = Array::ones((n_samples, 1));
             let X = stack(Axis(1), &[dummy_column.view(), X.view()]).unwrap();
-            self._predict(X)
+            self._predict(&X)
         } else {
             self._predict(X)
         }

--- a/examples/linear_regression.rs
+++ b/examples/linear_regression.rs
@@ -1,0 +1,69 @@
+use ndarray::{Array1, ArrayBase, Array2, stack, Axis, Array, Ix2, Data};
+use ndarray_linalg::{Solve};
+
+
+/// The simple linear regression model is
+///     y = bX + e  where e ~ N(0, sigma^2 * I)
+/// In probabilistic terms this corresponds to
+///     y - bX ~ N(0, sigma^2 * I)
+///     y | X, b ~ N(bX, sigma^2 * I)
+/// The loss for the model is simply the squared error between the model
+/// predictions and the true values:
+///     Loss = ||y - bX||^2
+/// The MLE for the model parameters b can be computed in closed form via the
+/// normal equation:
+///     b = (X^T X)^{-1} X^T y
+/// where (X^T X)^{-1} X^T is known as the pseudoinverse / Moore-Penrose
+/// inverse.
+struct LinearRegression {
+    beta: Option<Array1<f32>>,
+    fit_intercept: bool,
+}
+
+impl LinearRegression {
+    fn new(fit_intercept: bool) -> LinearRegression {
+        LinearRegression {
+            beta: None,
+            fit_intercept
+        }
+    }
+
+    fn fit(&mut self, mut X: Array2<f32>, y: Array1<f32>) {
+        let (n_samples, n_features) = X.dim();
+
+        // Check that our inputs have compatible shapes
+        assert_eq!(y.dim(), n_samples);
+
+        // If we are fitting the intercept, we need an additional column
+        if self.fit_intercept {
+            let dummy_column: Array<f32, _> = Array::ones((n_samples, 1));
+            X = stack(Axis(1), &[dummy_column.view(), X.view()]).unwrap();
+        };
+
+        let rhs = X.t().dot(&y);
+        let linear_operator = X.t().dot(&X);
+        self.beta = Some(linear_operator.solve_into(rhs).unwrap());
+    }
+
+    fn predict<A>(&self, mut X: &mut ArrayBase<A, Ix2>) -> Array1<f32>
+    where
+        A: Data<Elem=f32>,
+    {
+        let (n_samples, n_features) = X.dim();
+
+        // If we are fitting the intercept, we need an additional column
+        let X = if self.fit_intercept {
+            let dummy_column: Array<f32, _> = Array::ones((n_samples, 1));
+            stack(Axis(1), &[dummy_column.view(), X.view()]).unwrap()
+        } else {
+            X.to_owned()
+        };
+
+        match &self.beta {
+            None => panic!("The linear regression estimator has to be fitted first!"),
+            Some(beta) => {
+                X.dot(beta)
+            }
+        }
+    }
+}

--- a/examples/linear_regression.rs
+++ b/examples/linear_regression.rs
@@ -109,11 +109,14 @@ pub fn main() {
     let n_train_samples = 5000;
     let n_test_samples = 1000;
     let n_features = 3;
+
     let (X, y) = get_data(n_train_samples + n_test_samples, n_features);
     let (X_train, X_test) = X.view().split_at(Axis(0), n_train_samples);
     let (y_train, y_test) = y.view().split_at(Axis(0), n_train_samples);
+
     let mut linear_regressor = LinearRegression::new(false);
     linear_regressor.fit(X_train, y_train);
+
     let test_predictions = linear_regressor.predict(&X_test);
     let mean_squared_error = test_predictions.mean_sq_err(&y_test.to_owned()).unwrap();
     println!("Beta estimated from the training data: {:.3}", linear_regressor.beta.unwrap());

--- a/examples/linear_regression.rs
+++ b/examples/linear_regression.rs
@@ -1,8 +1,8 @@
 #![allow(non_snake_case)]
-use ndarray::{Array1, ArrayBase, Array2, stack, Axis, Array, Ix2, Ix1, Data};
-use ndarray_linalg::{Solve, random};
-use ndarray_stats::DeviationExt;
+use ndarray::{stack, Array, Array1, Array2, ArrayBase, Axis, Data, Ix1, Ix2};
+use ndarray_linalg::{random, Solve};
 use ndarray_rand::RandomExt;
+use ndarray_stats::DeviationExt;
 use rand::distributions::StandardNormal;
 
 /// The simple linear regression model is
@@ -28,14 +28,14 @@ impl LinearRegression {
     fn new(fit_intercept: bool) -> LinearRegression {
         LinearRegression {
             beta: None,
-            fit_intercept
+            fit_intercept,
         }
     }
 
     fn fit<A, B>(&mut self, X: ArrayBase<A, Ix2>, y: ArrayBase<B, Ix1>)
     where
-        A: Data<Elem=f64>,
-        B: Data<Elem=f64>,
+        A: Data<Elem = f64>,
+        B: Data<Elem = f64>,
     {
         let (n_samples, _) = X.dim();
 
@@ -53,9 +53,9 @@ impl LinearRegression {
     }
 
     fn solve_normal_equation<A, B>(X: ArrayBase<A, Ix2>, y: ArrayBase<B, Ix1>) -> Array1<f64>
-        where
-            A: Data<Elem=f64>,
-            B: Data<Elem=f64>,
+    where
+        A: Data<Elem = f64>,
+        B: Data<Elem = f64>,
     {
         let rhs = X.t().dot(&y);
         let linear_operator = X.t().dot(&X);
@@ -64,7 +64,7 @@ impl LinearRegression {
 
     fn predict<A>(&self, X: &ArrayBase<A, Ix2>) -> Array1<f64>
     where
-        A: Data<Elem=f64>,
+        A: Data<Elem = f64>,
     {
         let (n_samples, _) = X.dim();
 
@@ -79,21 +79,17 @@ impl LinearRegression {
     }
 
     fn _predict<A>(&self, X: &ArrayBase<A, Ix2>) -> Array1<f64>
-        where
-            A: Data<Elem=f64>,
+    where
+        A: Data<Elem = f64>,
     {
         match &self.beta {
             None => panic!("The linear regression estimator has to be fitted first!"),
-            Some(beta) => {
-                X.dot(beta)
-            }
+            Some(beta) => X.dot(beta),
         }
     }
 }
 
-fn get_data(n_samples: usize, n_features: usize) -> (
-    Array2<f64>, Array1<f64>
-) {
+fn get_data(n_samples: usize, n_features: usize) -> (Array2<f64>, Array1<f64>) {
     let shape = (n_samples, n_features);
     let noise: Array1<f64> = Array::random(n_samples, StandardNormal);
 
@@ -119,6 +115,12 @@ pub fn main() {
 
     let test_predictions = linear_regressor.predict(&X_test);
     let mean_squared_error = test_predictions.mean_sq_err(&y_test.to_owned()).unwrap();
-    println!("Beta estimated from the training data: {:.3}", linear_regressor.beta.unwrap());
-    println!("The fitted regressor has a root mean squared error of {:.3}", mean_squared_error);
+    println!(
+        "Beta estimated from the training data: {:.3}",
+        linear_regressor.beta.unwrap()
+    );
+    println!(
+        "The fitted regressor has a root mean squared error of {:.3}",
+        mean_squared_error
+    );
 }

--- a/examples/linear_regression.rs
+++ b/examples/linear_regression.rs
@@ -69,13 +69,19 @@ impl LinearRegression {
         let (n_samples, _) = X.dim();
 
         // If we are fitting the intercept, we need an additional column
-        let X = if self.fit_intercept {
+        if self.fit_intercept {
             let dummy_column: Array<f64, _> = Array::ones((n_samples, 1));
-            stack(Axis(1), &[dummy_column.view(), X.view()]).unwrap()
+            let X = stack(Axis(1), &[dummy_column.view(), X.view()]).unwrap();
+            self._predict(X)
         } else {
-            X.to_owned()
-        };
+            self._predict(X)
+        }
+    }
 
+    fn _predict<A>(&self, X: &ArrayBase<A, Ix2>) -> Array1<f64>
+        where
+            A: Data<Elem=f64>,
+    {
         match &self.beta {
             None => panic!("The linear regression estimator has to be fitted first!"),
             Some(beta) => {

--- a/examples/linear_regression.rs
+++ b/examples/linear_regression.rs
@@ -1,5 +1,6 @@
 use ndarray::{Array1, ArrayBase, Array2, stack, Axis, Array, Ix2, Data};
-use ndarray_linalg::{Solve};
+use ndarray_linalg::{Solve, random};
+use ndarray_stats::DeviationExt;
 
 
 /// The simple linear regression model is
@@ -45,7 +46,7 @@ impl LinearRegression {
         self.beta = Some(linear_operator.solve_into(rhs).unwrap());
     }
 
-    fn predict<A>(&self, mut X: &mut ArrayBase<A, Ix2>) -> Array1<f32>
+    fn predict<A>(&self, mut X: &ArrayBase<A, Ix2>) -> Array1<f32>
     where
         A: Data<Elem=f32>,
     {
@@ -66,4 +67,26 @@ impl LinearRegression {
             }
         }
     }
+}
+
+fn get_data(n_train_samples: usize, n_test_samples: usize, n_features: usize) -> (
+    Array2<f32>, Array2<f32>, Array1<f32>, Array1<f32>
+) {
+    let X_train: Array2<f32> = random((n_train_samples, n_features));
+    let y_train: Array1<f32> = random(n_train_samples);
+    let X_test: Array2<f32> = random((n_test_samples, n_features));
+    let y_test: Array1<f32> = random(n_test_samples);
+    (X_train, X_test, y_train, y_test)
+}
+
+pub fn main() {
+    let n_train_samples = 5000;
+    let n_test_samples = 1000;
+    let n_features = 15;
+    let (X_train, X_test, y_train, y_test) = get_data(n_train_samples, n_test_samples, n_features);
+    let mut linear_regressor = LinearRegression::new(true);
+    linear_regressor.fit(X_train, y_train);
+    let test_predictions = linear_regressor.predict(&X_test);
+    let mean_squared_error = test_predictions.sq_l2_dist(&y_test).unwrap();
+    println!("The fitted regressor has a root mean squared error of {:}", mean_squared_error);
 }

--- a/examples/linear_regression.rs
+++ b/examples/linear_regression.rs
@@ -1,3 +1,4 @@
+#![allow(non_snake_case)]
 use ndarray::{Array1, ArrayBase, Array2, stack, Axis, Array, Ix2, Data};
 use ndarray_linalg::{Solve, random};
 use ndarray_stats::DeviationExt;
@@ -30,7 +31,7 @@ impl LinearRegression {
     }
 
     fn fit(&mut self, mut X: Array2<f32>, y: Array1<f32>) {
-        let (n_samples, n_features) = X.dim();
+        let (n_samples, _) = X.dim();
 
         // Check that our inputs have compatible shapes
         assert_eq!(y.dim(), n_samples);
@@ -46,11 +47,11 @@ impl LinearRegression {
         self.beta = Some(linear_operator.solve_into(rhs).unwrap());
     }
 
-    fn predict<A>(&self, mut X: &ArrayBase<A, Ix2>) -> Array1<f32>
+    fn predict<A>(&self, X: &ArrayBase<A, Ix2>) -> Array1<f32>
     where
         A: Data<Elem=f32>,
     {
-        let (n_samples, n_features) = X.dim();
+        let (n_samples, _) = X.dim();
 
         // If we are fitting the intercept, we need an additional column
         let X = if self.fit_intercept {

--- a/examples/linear_regression.rs
+++ b/examples/linear_regression.rs
@@ -120,7 +120,7 @@ pub fn main() {
         linear_regressor.beta.unwrap()
     );
     println!(
-        "The fitted regressor has a root mean squared error of {:.3}",
+        "The fitted regressor has a mean squared error of {:.3}",
         mean_squared_error
     );
 }

--- a/examples/linear_regression/linear_regression.rs
+++ b/examples/linear_regression/linear_regression.rs
@@ -15,7 +15,7 @@ use ndarray_linalg::Solve;
 ///     b = (X^T X)^{-1} X^T y
 /// where (X^T X)^{-1} X^T is known as the pseudoinverse or Moore-Penrose inverse.
 ///
-/// Adapted from: https://github.com/xinscrs/numpy-ml
+/// Adapted from: https://github.com/ddbourgin/numpy-ml
 pub struct LinearRegression {
     pub beta: Option<Array1<f64>>,
     fit_intercept: bool,

--- a/examples/linear_regression/linear_regression.rs
+++ b/examples/linear_regression/linear_regression.rs
@@ -29,6 +29,13 @@ impl LinearRegression {
         }
     }
 
+    /// Given:
+    /// - an input matrix `X`, with shape `(n_samples, n_features)`;
+    /// - a target variable `y`, with shape `(n_samples,)`;
+    /// `fit` tunes the `beta` parameter of the linear regression model
+    /// to match the training data distribution.
+    ///
+    /// `self` is modified in place, nothing is returned.
     pub fn fit<A, B>(&mut self, X: ArrayBase<A, Ix2>, y: ArrayBase<B, Ix1>)
     where
         A: Data<Elem = f64>,
@@ -49,6 +56,11 @@ impl LinearRegression {
         };
     }
 
+    /// Given an input matrix `X`, with shape `(n_samples, n_features)`,
+    /// `predict` returns the target variable according to linear model
+    /// learned from the training data distribution.
+    ///
+    /// **Panics** if `self` has not be `fit`ted before calling `predict.
     pub fn predict<A>(&self, X: &ArrayBase<A, Ix2>) -> Array1<f64>
         where
             A: Data<Elem = f64>,

--- a/examples/linear_regression/linear_regression.rs
+++ b/examples/linear_regression/linear_regression.rs
@@ -1,9 +1,6 @@
 #![allow(non_snake_case)]
-use ndarray::{stack, Array, Array1, Array2, ArrayBase, Axis, Data, Ix1, Ix2};
-use ndarray_linalg::{random, Solve};
-use ndarray_rand::RandomExt;
-use ndarray_stats::DeviationExt;
-use rand::distributions::StandardNormal;
+use ndarray::{stack, Array, Array1, ArrayBase, Axis, Data, Ix1, Ix2};
+use ndarray_linalg::Solve;
 
 /// The simple linear regression model is
 ///     y = bX + e  where e ~ N(0, sigma^2 * I)
@@ -19,20 +16,20 @@ use rand::distributions::StandardNormal;
 /// where (X^T X)^{-1} X^T is known as the pseudoinverse or Moore-Penrose inverse.
 ///
 /// Adapted from: https://github.com/xinscrs/numpy-ml
-struct LinearRegression {
+pub struct LinearRegression {
     pub beta: Option<Array1<f64>>,
     fit_intercept: bool,
 }
 
 impl LinearRegression {
-    fn new(fit_intercept: bool) -> LinearRegression {
+    pub fn new(fit_intercept: bool) -> LinearRegression {
         LinearRegression {
             beta: None,
             fit_intercept,
         }
     }
 
-    fn fit<A, B>(&mut self, X: ArrayBase<A, Ix2>, y: ArrayBase<B, Ix1>)
+    pub fn fit<A, B>(&mut self, X: ArrayBase<A, Ix2>, y: ArrayBase<B, Ix1>)
     where
         A: Data<Elem = f64>,
         B: Data<Elem = f64>,
@@ -52,19 +49,9 @@ impl LinearRegression {
         };
     }
 
-    fn solve_normal_equation<A, B>(X: ArrayBase<A, Ix2>, y: ArrayBase<B, Ix1>) -> Array1<f64>
-    where
-        A: Data<Elem = f64>,
-        B: Data<Elem = f64>,
-    {
-        let rhs = X.t().dot(&y);
-        let linear_operator = X.t().dot(&X);
-        linear_operator.solve_into(rhs).unwrap()
-    }
-
-    fn predict<A>(&self, X: &ArrayBase<A, Ix2>) -> Array1<f64>
-    where
-        A: Data<Elem = f64>,
+    pub fn predict<A>(&self, X: &ArrayBase<A, Ix2>) -> Array1<f64>
+        where
+            A: Data<Elem = f64>,
     {
         let (n_samples, _) = X.dim();
 
@@ -78,6 +65,16 @@ impl LinearRegression {
         }
     }
 
+    fn solve_normal_equation<A, B>(X: ArrayBase<A, Ix2>, y: ArrayBase<B, Ix1>) -> Array1<f64>
+    where
+        A: Data<Elem = f64>,
+        B: Data<Elem = f64>,
+    {
+        let rhs = X.t().dot(&y);
+        let linear_operator = X.t().dot(&X);
+        linear_operator.solve_into(rhs).unwrap()
+    }
+
     fn _predict<A>(&self, X: &ArrayBase<A, Ix2>) -> Array1<f64>
     where
         A: Data<Elem = f64>,
@@ -87,40 +84,4 @@ impl LinearRegression {
             Some(beta) => X.dot(beta),
         }
     }
-}
-
-fn get_data(n_samples: usize, n_features: usize) -> (Array2<f64>, Array1<f64>) {
-    let shape = (n_samples, n_features);
-    let noise: Array1<f64> = Array::random(n_samples, StandardNormal);
-
-    let beta: Array1<f64> = random(n_features) * 10.;
-    println!("Beta used to generate target variable: {:.3}", beta);
-
-    let X: Array2<f64> = random(shape);
-    let y: Array1<f64> = X.dot(&beta) + noise;
-    (X, y)
-}
-
-pub fn main() {
-    let n_train_samples = 5000;
-    let n_test_samples = 1000;
-    let n_features = 3;
-
-    let (X, y) = get_data(n_train_samples + n_test_samples, n_features);
-    let (X_train, X_test) = X.view().split_at(Axis(0), n_train_samples);
-    let (y_train, y_test) = y.view().split_at(Axis(0), n_train_samples);
-
-    let mut linear_regressor = LinearRegression::new(false);
-    linear_regressor.fit(X_train, y_train);
-
-    let test_predictions = linear_regressor.predict(&X_test);
-    let mean_squared_error = test_predictions.mean_sq_err(&y_test.to_owned()).unwrap();
-    println!(
-        "Beta estimated from the training data: {:.3}",
-        linear_regressor.beta.unwrap()
-    );
-    println!(
-        "The fitted regressor has a mean squared error of {:.3}",
-        mean_squared_error
-    );
 }

--- a/examples/linear_regression/main.rs
+++ b/examples/linear_regression/main.rs
@@ -1,0 +1,49 @@
+#![allow(non_snake_case)]
+use ndarray::{Array1, Array2, Array, Axis};
+use ndarray_linalg::random;
+use ndarray_stats::DeviationExt;
+use ndarray_rand::RandomExt;
+use rand::distributions::StandardNormal;
+
+// Import LinearRegression from other file ("module") in this example
+mod linear_regression;
+use linear_regression::LinearRegression;
+
+/// It returns a tuple: input data and the associated target variable.
+///
+/// The target variable is a linear function of the input, perturbed by gaussian noise.
+fn get_data(n_samples: usize, n_features: usize) -> (Array2<f64>, Array1<f64>) {
+    let shape = (n_samples, n_features);
+    let noise: Array1<f64> = Array::random(n_samples, StandardNormal);
+
+    let beta: Array1<f64> = random(n_features) * 10.;
+    println!("Beta used to generate target variable: {:.3}", beta);
+
+    let X: Array2<f64> = random(shape);
+    let y: Array1<f64> = X.dot(&beta) + noise;
+    (X, y)
+}
+
+pub fn main() {
+    let n_train_samples = 5000;
+    let n_test_samples = 1000;
+    let n_features = 3;
+
+    let (X, y) = get_data(n_train_samples + n_test_samples, n_features);
+    let (X_train, X_test) = X.view().split_at(Axis(0), n_train_samples);
+    let (y_train, y_test) = y.view().split_at(Axis(0), n_train_samples);
+
+    let mut linear_regressor = LinearRegression::new(false);
+    linear_regressor.fit(X_train, y_train);
+
+    let test_predictions = linear_regressor.predict(&X_test);
+    let mean_squared_error = test_predictions.mean_sq_err(&y_test.to_owned()).unwrap();
+    println!(
+        "Beta estimated from the training data: {:.3}",
+        linear_regressor.beta.unwrap()
+    );
+    println!(
+        "The fitted regressor has a mean squared error of {:.3}",
+        mean_squared_error
+    );
+}


### PR DESCRIPTION
I have started to port some very simple Python code to Rust to explore the ergonomics of what is currently available for ML and better understand the design challenges (see https://github.com/rust-ml/classical-ml-discussion/pull/2#issuecomment-510811591).

This is quite an easy example that brings together `ndarray-linalg`, `ndarray` and `ndarray-stats` (which is what we were looking for in https://github.com/rust-ndarray/ndarray-stats/issues/47 ) - right now I lean towards the idea of hosting it in the `examples` collection for `ndarray-linalg`, but I am open to suggestions.

What do you think? @jturner314 @termoshtt @munckymagik
(Also, do you think it is actually a useful example to have in any of those crates?)