### PR TITLE
Remove spurious `dbg` log.

### DIFF
--- a/src/lapack/svd.rs
+++ b/src/lapack/svd.rs
@@ -51,7 +51,6 @@ macro_rules! impl_svd {
                 };
                 let mut s = vec![Self::Real::zero(); k as usize];
                 let mut superb = vec![Self::Real::zero(); (k - 1) as usize];
-                dbg!(ldvt);
                 let info = $gesvd(
                     l.lapacke_layout(),
                     ju as u8,


### PR DESCRIPTION
Code that calls `svd` has no way of getting around this `dbg` log to stderr, which causes a lot of noise.

This PR removes that line.