### PR TITLE
Split LAPACK error into Computational failure and invalid value

### DIFF
--- a/ndarray-linalg/src/error.rs
+++ b/ndarray-linalg/src/error.rs
@@ -12,9 +12,17 @@ pub enum LinalgError {
     #[error("Not square: rows({}) != cols({})", rows, cols)]
     NotSquare { rows: i32, cols: i32 },
 
-    /// LAPACK subroutine returns non-zero code
-    #[error("LAPACK: return_code = {}", return_code)]
-    Lapack { return_code: i32 },
+    #[error(
+        "Invalid value for LAPACK subroutine {}-th argument",
+        -return_code
+    )]
+    LapackInvalidValue { return_code: i32 },
+
+    #[error(
+        "Comutational failure in LAPACK subroutine: return_code = {}",
+        return_code
+    )]
+    LapackComputationalFailure { return_code: i32 },
 
     /// Strides of the array is not supported
     #[error("invalid stride: s0={}, s1={}", s0, s1)]

--- a/ndarray-linalg/src/lapack/cholesky.rs
+++ b/ndarray-linalg/src/lapack/cholesky.rs
@@ -1,10 +1,7 @@
 //! Cholesky decomposition
 
-use crate::error::*;
-use crate::layout::MatrixLayout;
-use crate::types::*;
-
-use super::{into_result, UPLO};
+use super::*;
+use crate::{error::*, layout::MatrixLayout, types::*};
 
 pub trait Cholesky_: Sized {
     /// Cholesky: wrapper of `*potrf`
@@ -25,14 +22,14 @@ macro_rules! impl_cholesky {
         impl Cholesky_ for $scalar {
             unsafe fn cholesky(l: MatrixLayout, uplo: UPLO, a: &mut [Self]) -> Result<()> {
                 let (n, _) = l.size();
-                let info = $trf(l.lapacke_layout(), uplo as u8, n, a, n);
-                into_result(info, ())
+                $trf(l.lapacke_layout(), uplo as u8, n, a, n).as_lapack_result()?;
+                Ok(())
             }
 
             unsafe fn inv_cholesky(l: MatrixLayout, uplo: UPLO, a: &mut [Self]) -> Result<()> {
                 let (n, _) = l.size();
-                let info = $tri(l.lapacke_layout(), uplo as u8, n, a, l.lda());
-                into_result(info, ())
+                $tri(l.lapacke_layout(), uplo as u8, n, a, l.lda()).as_lapack_result()?;
+                Ok(())
             }
 
             unsafe fn solve_cholesky(
@@ -44,8 +41,9 @@ macro_rules! impl_cholesky {
                 let (n, _) = l.size();
                 let nrhs = 1;
                 let ldb = 1;
-                let info = $trs(l.lapacke_layout(), uplo as u8, n, nrhs, a, l.lda(), b, ldb);
-                into_result(info, ())
+                $trs(l.lapacke_layout(), uplo as u8, n, nrhs, a, l.lda(), b, ldb)
+                    .as_lapack_result()?;
+                Ok(())
             }
         }
     };

--- a/ndarray-linalg/src/lapack/eigh.rs
+++ b/ndarray-linalg/src/lapack/eigh.rs
@@ -1,12 +1,8 @@
 //! Eigenvalue decomposition for Hermite matrices
 
+use super::*;
+use crate::{error::*, layout::MatrixLayout, types::*};
 use num_traits::Zero;
-
-use crate::error::*;
-use crate::layout::MatrixLayout;
-use crate::types::*;
-
-use super::{into_result, UPLO};
 
 /// Wraps `*syev` for real and `*heev` for complex
 pub trait Eigh_: Scalar {
@@ -37,8 +33,9 @@ macro_rules! impl_eigh {
                 let (n, _) = l.size();
                 let jobz = if calc_v { b'V' } else { b'N' };
                 let mut w = vec![Self::Real::zero(); n as usize];
-                let info = $ev(l.lapacke_layout(), jobz, uplo as u8, n, &mut a, n, &mut w);
-                into_result(info, w)
+                $ev(l.lapacke_layout(), jobz, uplo as u8, n, &mut a, n, &mut w)
+                    .as_lapack_result()?;
+                Ok(w)
             }
 
             unsafe fn eigh_generalized(
@@ -51,7 +48,7 @@ macro_rules! impl_eigh {
                 let (n, _) = l.size();
                 let jobz = if calc_v { b'V' } else { b'N' };
                 let mut w = vec![Self::Real::zero(); n as usize];
-                let info = $evg(
+                $evg(
                     l.lapacke_layout(),
                     1,
                     jobz,
@@ -62,8 +59,9 @@ macro_rules! impl_eigh {
                     &mut b,
                     n,
                     &mut w,
-                );
-                into_result(info, w)
+                )
+                .as_lapack_result()?;
+                Ok(w)
             }
         }
     };

--- a/ndarray-linalg/src/lapack/least_squares.rs
+++ b/ndarray-linalg/src/lapack/least_squares.rs
@@ -1,13 +1,9 @@
 //! Least squares
 
+use super::*;
+use crate::{error::*, layout::MatrixLayout, types::*};
 use ndarray::{ErrorKind, ShapeError};
 use num_traits::Zero;
-
-use crate::error::*;
-use crate::layout::MatrixLayout;
-use crate::types::*;
-
-use super::into_result;
 
 /// Result of LeastSquares
 pub struct LeastSquaresOutput<A: Scalar> {
@@ -53,7 +49,7 @@ macro_rules! impl_least_squares {
                 let mut singular_values: Vec<Self::Real> = vec![Self::Real::zero(); k as usize];
                 let mut rank: i32 = 0;
 
-                let status = $gelsd(
+                $gelsd(
                     a_layout.lapacke_layout(),
                     m,
                     n,
@@ -67,15 +63,13 @@ macro_rules! impl_least_squares {
                     &mut singular_values,
                     rcond,
                     &mut rank,
-                );
-
-                into_result(
-                    status,
-                    LeastSquaresOutput {
-                        singular_values,
-                        rank,
-                    },
                 )
+                .as_lapack_result()?;
+
+                Ok(LeastSquaresOutput {
+                    singular_values,
+                    rank,
+                })
             }
 
             unsafe fn least_squares_nrhs(
@@ -99,7 +93,7 @@ macro_rules! impl_least_squares {
                 let mut singular_values: Vec<Self::Real> = vec![Self::Real::zero(); k as usize];
                 let mut rank: i32 = 0;
 
-                let status = $gelsd(
+                $gelsd(
                     a_layout.lapacke_layout(),
                     m,
                     n,
@@ -111,15 +105,12 @@ macro_rules! impl_least_squares {
                     &mut singular_values,
                     rcond,
                     &mut rank,
-                );
-
-                into_result(
-                    status,
-                    LeastSquaresOutput {
-                        singular_values,
-                        rank,
-                    },
                 )
+                .as_lapack_result()?;
+                Ok(LeastSquaresOutput {
+                    singular_values,
+                    rank,
+                })
             }
         }
     };

--- a/ndarray-linalg/src/lapack/mod.rs
+++ b/ndarray-linalg/src/lapack/mod.rs
@@ -54,11 +54,19 @@ impl Lapack for f64 {}
 impl Lapack for c32 {}
 impl Lapack for c64 {}
 
-pub fn into_result<T>(return_code: i32, val: T) -> Result<T> {
-    if return_code == 0 {
-        Ok(val)
-    } else {
-        Err(LinalgError::Lapack { return_code })
+trait AsLapackResult {
+    fn as_lapack_result(self) -> Result<()>;
+}
+
+impl AsLapackResult for i32 {
+    fn as_lapack_result(self) -> Result<()> {
+        if self > 0 {
+            return Err(LinalgError::LapackComputationalFailure { return_code: self });
+        }
+        if self < 0 {
+            return Err(LinalgError::LapackInvalidValue { return_code: self });
+        }
+        Ok(())
     }
 }
 

--- a/ndarray-linalg/src/lapack/qr.rs
+++ b/ndarray-linalg/src/lapack/qr.rs
@@ -1,13 +1,9 @@
 //! QR decomposition
 
+use super::*;
+use crate::{error::*, layout::MatrixLayout, types::*};
 use num_traits::Zero;
 use std::cmp::min;
-
-use crate::error::*;
-use crate::layout::MatrixLayout;
-use crate::types::*;
-
-use super::into_result;
 
 /// Wraps `*geqrf` and `*orgqr` (`*ungqr` for complex numbers)
 pub trait QR_: Sized {
@@ -23,15 +19,15 @@ macro_rules! impl_qr {
                 let (row, col) = l.size();
                 let k = min(row, col);
                 let mut tau = vec![Self::zero(); k as usize];
-                let info = $qrf(l.lapacke_layout(), row, col, &mut a, l.lda(), &mut tau);
-                into_result(info, tau)
+                $qrf(l.lapacke_layout(), row, col, &mut a, l.lda(), &mut tau).as_lapack_result()?;
+                Ok(tau)
             }
 
             unsafe fn q(l: MatrixLayout, mut a: &mut [Self], tau: &[Self]) -> Result<()> {
                 let (row, col) = l.size();
                 let k = min(row, col);
-                let info = $gqr(l.lapacke_layout(), row, k, k, &mut a, l.lda(), &tau);
-                into_result(info, ())
+                $gqr(l.lapacke_layout(), row, k, k, &mut a, l.lda(), &tau).as_lapack_result()?;
+                Ok(())
             }
 
             unsafe fn qr(l: MatrixLayout, a: &mut [Self]) -> Result<Vec<Self>> {

--- a/ndarray-linalg/src/lapack/svd.rs
+++ b/ndarray-linalg/src/lapack/svd.rs
@@ -1,12 +1,8 @@
 //! Singular-value decomposition
 
+use super::*;
+use crate::{error::*, layout::MatrixLayout, types::*};
 use num_traits::Zero;
-
-use crate::error::*;
-use crate::layout::MatrixLayout;
-use crate::types::*;
-
-use super::into_result;
 
 #[repr(u8)]
 enum FlagSVD {
@@ -60,7 +56,7 @@ macro_rules! impl_svd {
                 };
                 let mut s = vec![Self::Real::zero(); k as usize];
                 let mut superb = vec![Self::Real::zero(); (k - 1) as usize];
-                let info = $gesvd(
+                $gesvd(
                     l.lapacke_layout(),
                     ju as u8,
                     jvt as u8,
@@ -74,15 +70,13 @@ macro_rules! impl_svd {
                     &mut vt,
                     ldvt,
                     &mut superb,
-                );
-                into_result(
-                    info,
-                    SVDOutput {
-                        s,
-                        u: if calc_u { Some(u) } else { None },
-                        vt: if calc_vt { Some(vt) } else { None },
-                    },
                 )
+                .as_lapack_result()?;
+                Ok(SVDOutput {
+                    s,
+                    u: if calc_u { Some(u) } else { None },
+                    vt: if calc_vt { Some(vt) } else { None },
+                })
             }
         }
     };

--- a/ndarray-linalg/src/lapack/triangular.rs
+++ b/ndarray-linalg/src/lapack/triangular.rs
@@ -1,10 +1,7 @@
 //! Implement linear solver and inverse matrix
 
-use super::{into_result, Transpose, UPLO};
-
-use crate::error::*;
-use crate::layout::MatrixLayout;
-use crate::types::*;
+use super::*;
+use crate::{error::*, layout::MatrixLayout, types::*};
 
 #[derive(Debug, Clone, Copy)]
 #[repr(u8)]
@@ -37,8 +34,8 @@ macro_rules! impl_triangular {
             ) -> Result<()> {
                 let (n, _) = l.size();
                 let lda = l.lda();
-                let info = $trtri(l.lapacke_layout(), uplo as u8, diag as u8, n, a, lda);
-                into_result(info, ())
+                $trtri(l.lapacke_layout(), uplo as u8, diag as u8, n, a, lda).as_lapack_result()?;
+                Ok(())
             }
 
             unsafe fn solve_triangular(
@@ -53,7 +50,7 @@ macro_rules! impl_triangular {
                 let lda = al.lda();
                 let (_, nrhs) = bl.size();
                 let ldb = bl.lda();
-                let info = $trtrs(
+                $trtrs(
                     al.lapacke_layout(),
                     uplo as u8,
                     Transpose::No as u8,
@@ -64,8 +61,9 @@ macro_rules! impl_triangular {
                     lda,
                     &mut b,
                     ldb,
-                );
-                into_result(info, ())
+                )
+                .as_lapack_result()?;
+                Ok(())
             }
         }
     };

--- a/ndarray-linalg/src/lobpcg/lobpcg.rs
+++ b/ndarray-linalg/src/lobpcg/lobpcg.rs
@@ -337,7 +337,7 @@ pub fn lobpcg<
         // if this fails (or the algorithm was restarted), then just use span{R, X}
         let result = p_ap
             .as_ref()
-            .ok_or(LinalgError::Lapack { return_code: 1 })
+            .ok_or(LinalgError::LapackComputationalFailure { return_code: 1 })
             .and_then(|(active_p, active_ap)| {
                 let xap = x.t().dot(active_ap);
                 let rap = r.t().dot(active_ap);

--- a/ndarray-linalg/src/solve.rs
+++ b/ndarray-linalg/src/solve.rs
@@ -476,7 +476,7 @@ where
         self.ensure_square()?;
         match self.factorize() {
             Ok(fac) => fac.sln_det(),
-            Err(LinalgError::Lapack { return_code }) if return_code > 0 => {
+            Err(LinalgError::LapackComputationalFailure { .. }) => {
                 // The determinant is zero.
                 Ok((A::zero(), A::Real::neg_infinity()))
             }
@@ -494,7 +494,7 @@ where
         self.ensure_square()?;
         match self.factorize_into() {
             Ok(fac) => fac.sln_det_into(),
-            Err(LinalgError::Lapack { return_code }) if return_code > 0 => {
+            Err(LinalgError::LapackComputationalFailure { .. }) => {
                 // The determinant is zero.
                 Ok((A::zero(), A::Real::neg_infinity()))
             }

--- a/ndarray-linalg/src/solveh.rs
+++ b/ndarray-linalg/src/solveh.rs
@@ -423,7 +423,7 @@ where
     fn sln_deth(&self) -> Result<(A::Real, A::Real)> {
         match self.factorizeh() {
             Ok(fac) => Ok(fac.sln_deth()),
-            Err(LinalgError::Lapack { return_code }) if return_code > 0 => {
+            Err(LinalgError::LapackComputationalFailure { .. }) => {
                 // Determinant is zero.
                 Ok((A::Real::zero(), A::Real::neg_infinity()))
             }
@@ -447,7 +447,7 @@ where
     fn sln_deth_into(self) -> Result<(A::Real, A::Real)> {
         match self.factorizeh_into() {
             Ok(fac) => Ok(fac.sln_deth_into()),
-            Err(LinalgError::Lapack { return_code }) if return_code > 0 => {
+            Err(LinalgError::LapackComputationalFailure { .. }) => {
                 // Determinant is zero.
                 Ok((A::Real::zero(), A::Real::neg_infinity()))
             }


### PR DESCRIPTION
Split from #207 

- Split LAPACK error into Computational failure (INFO > 0) and invalid value (INFO < 0)
- minor edit for use sentence
- `into_result` -> `as_lapack_error`