### PR TITLE
Uninitialize working memory

### DIFF
--- a/lax/src/eig.rs
+++ b/lax/src/eig.rs
@@ -1,6 +1,6 @@
 //! Eigenvalue decomposition for general matrices
 
-use crate::{error::*, layout::MatrixLayout};
+use crate::{error::*, layout::MatrixLayout, *};
 use cauchy::*;
 use num_traits::{ToPrimitive, Zero};
 
@@ -33,16 +33,16 @@ macro_rules! impl_eig_complex {
                 } else {
                     (b'N', b'N')
                 };
-                let mut eigs = vec![Self::Complex::zero(); n as usize];
-                let mut rwork = vec![Self::Real::zero(); 2 * n as usize];
+                let mut eigs = unsafe { vec_uninit(n as usize) };
+                let mut rwork = unsafe { vec_uninit(2 * n as usize) };
 
                 let mut vl = if jobvl == b'V' {
-                    Some(vec![Self::Complex::zero(); (n * n) as usize])
+                    Some(unsafe { vec_uninit((n * n) as usize) })
                 } else {
                     None
                 };
                 let mut vr = if jobvr == b'V' {
-                    Some(vec![Self::Complex::zero(); (n * n) as usize])
+                    Some(unsafe { vec_uninit((n * n) as usize) })
                 } else {
                     None
                 };
@@ -72,7 +72,7 @@ macro_rules! impl_eig_complex {
 
                 // actal ev
                 let lwork = work_size[0].to_usize().unwrap();
-                let mut work = vec![Self::zero(); lwork];
+                let mut work = unsafe { vec_uninit(lwork) };
                 unsafe {
                     $ev(
                         jobvl,
@@ -128,16 +128,16 @@ macro_rules! impl_eig_real {
                 } else {
                     (b'N', b'N')
                 };
-                let mut eig_re = vec![Self::zero(); n as usize];
-                let mut eig_im = vec![Self::zero(); n as usize];
+                let mut eig_re = unsafe { vec_uninit(n as usize) };
+                let mut eig_im = unsafe { vec_uninit(n as usize) };
 
                 let mut vl = if jobvl == b'V' {
-                    Some(vec![Self::zero(); (n * n) as usize])
+                    Some(unsafe { vec_uninit((n * n) as usize) })
                 } else {
                     None
                 };
                 let mut vr = if jobvr == b'V' {
-                    Some(vec![Self::zero(); (n * n) as usize])
+                    Some(unsafe { vec_uninit((n * n) as usize) })
                 } else {
                     None
                 };
@@ -167,7 +167,7 @@ macro_rules! impl_eig_real {
 
                 // actual ev
                 let lwork = work_size[0].to_usize().unwrap();
-                let mut work = vec![Self::zero(); lwork];
+                let mut work = unsafe { vec_uninit(lwork) };
                 unsafe {
                     $ev(
                         jobvl,
@@ -219,7 +219,7 @@ macro_rules! impl_eig_real {
                 // ```
                 let n = n as usize;
                 let v = vr.or(vl).unwrap();
-                let mut eigvecs = vec![Self::Complex::zero(); n * n];
+                let mut eigvecs = unsafe { vec_uninit(n * n) };
                 let mut is_conjugate_pair = false; // flag for check `j` is complex conjugate
                 for j in 0..n {
                     if eig_im[j] == 0.0 {

--- a/lax/src/eigh.rs
+++ b/lax/src/eigh.rs
@@ -42,10 +42,10 @@ macro_rules! impl_eigh {
                 assert_eq!(layout.len(), layout.lda());
                 let n = layout.len();
                 let jobz = if calc_v { b'V' } else { b'N' };
-                let mut eigs = vec![Self::Real::zero(); n as usize];
+                let mut eigs = unsafe { vec_uninit(n as usize) };
 
                 $(
-                let mut $rwork_ident = vec![Self::Real::zero(); 3 * n as usize - 2];
+                let mut $rwork_ident = unsafe { vec_uninit(3 * n as usize - 2 as usize) };
                 )*
 
                 // calc work size
@@ -69,7 +69,7 @@ macro_rules! impl_eigh {
 
                 // actual ev
                 let lwork = work_size[0].to_usize().unwrap();
-                let mut work = vec![Self::zero(); lwork];
+                let mut work = unsafe { vec_uninit(lwork) };
                 unsafe {
                     $ev(
                         jobz,
@@ -98,10 +98,10 @@ macro_rules! impl_eigh {
                 assert_eq!(layout.len(), layout.lda());
                 let n = layout.len();
                 let jobz = if calc_v { b'V' } else { b'N' };
-                let mut eigs = vec![Self::Real::zero(); n as usize];
+                let mut eigs = unsafe { vec_uninit(n as usize) };
 
                 $(
-                let mut $rwork_ident = vec![Self::Real::zero(); 3 * n as usize - 2];
+                let mut $rwork_ident = unsafe { vec_uninit(3 * n as usize - 2) };
                 )*
 
                 // calc work size
@@ -128,7 +128,7 @@ macro_rules! impl_eigh {
 
                 // actual evg
                 let lwork = work_size[0].to_usize().unwrap();
-                let mut work = vec![Self::zero(); lwork];
+                let mut work = unsafe { vec_uninit(lwork) };
                 unsafe {
                     $evg(
                         &[1],

--- a/lax/src/lib.rs
+++ b/lax/src/lib.rs
@@ -168,3 +168,15 @@ impl NormType {
         }
     }
 }
+
+/// Create a vector without initialization
+///
+/// Safety
+/// ------
+/// - Memory is not initialized. Do not read the memory before write.
+///
+unsafe fn vec_uninit<T: Sized>(n: usize) -> Vec<T> {
+    let mut v = Vec::with_capacity(n);
+    v.set_len(n);
+    v
+}

--- a/lax/src/opnorm.rs
+++ b/lax/src/opnorm.rs
@@ -1,9 +1,8 @@
 //! Operator norms of matrices
 
 use super::NormType;
-use crate::layout::MatrixLayout;
+use crate::{layout::MatrixLayout, *};
 use cauchy::*;
-use num_traits::Zero;
 
 pub trait OperatorNorm_: Scalar {
     fn opnorm(t: NormType, l: MatrixLayout, a: &[Self]) -> Self::Real;
@@ -20,7 +19,7 @@ macro_rules! impl_opnorm {
                     MatrixLayout::C { .. } => t.transpose(),
                 };
                 let mut work = if matches!(t, NormType::Infinity) {
-                    vec![Self::Real::zero(); m as usize]
+                    unsafe { vec_uninit(m as usize) }
                 } else {
                     Vec::new()
                 };

--- a/lax/src/qr.rs
+++ b/lax/src/qr.rs
@@ -1,6 +1,6 @@
 //! QR decomposition
 
-use crate::{error::*, layout::MatrixLayout};
+use crate::{error::*, layout::MatrixLayout, *};
 use cauchy::*;
 use num_traits::{ToPrimitive, Zero};
 
@@ -25,7 +25,7 @@ macro_rules! impl_qr {
                 let m = l.lda();
                 let n = l.len();
                 let k = m.min(n);
-                let mut tau = vec![Self::zero(); k as usize];
+                let mut tau = unsafe { vec_uninit(k as usize) };
 
                 // eval work size
                 let mut info = 0;
@@ -44,7 +44,7 @@ macro_rules! impl_qr {
 
                 // calc
                 let lwork = work_size[0].to_usize().unwrap();
-                let mut work = vec![Self::zero(); lwork];
+                let mut work = unsafe { vec_uninit(lwork) };
                 unsafe {
                     match l {
                         MatrixLayout::F { .. } => {
@@ -100,7 +100,7 @@ macro_rules! impl_qr {
 
                 // calc
                 let lwork = work_size[0].to_usize().unwrap();
-                let mut work = vec![Self::zero(); lwork];
+                let mut work = unsafe { vec_uninit(lwork) };
                 unsafe {
                     match l {
                         MatrixLayout::F { .. } => {

--- a/lax/src/rcond.rs
+++ b/lax/src/rcond.rs
@@ -1,5 +1,4 @@
-use super::*;
-use crate::{error::*, layout::MatrixLayout};
+use crate::{error::*, layout::MatrixLayout, *};
 use cauchy::*;
 use num_traits::Zero;
 
@@ -18,8 +17,8 @@ macro_rules! impl_rcond_real {
                 let mut rcond = Self::Real::zero();
                 let mut info = 0;
 
-                let mut work = vec![Self::zero(); 4 * n as usize];
-                let mut iwork = vec![0; n as usize];
+                let mut work = unsafe { vec_uninit(4 * n as usize) };
+                let mut iwork = unsafe { vec_uninit(n as usize) };
                 let norm_type = match l {
                     MatrixLayout::C { .. } => NormType::Infinity,
                     MatrixLayout::F { .. } => NormType::One,
@@ -55,8 +54,8 @@ macro_rules! impl_rcond_complex {
                 let (n, _) = l.size();
                 let mut rcond = Self::Real::zero();
                 let mut info = 0;
-                let mut work = vec![Self::zero(); 2 * n as usize];
-                let mut rwork = vec![Self::Real::zero(); 2 * n as usize];
+                let mut work = unsafe { vec_uninit(2 * n as usize) };
+                let mut rwork = unsafe { vec_uninit(2 * n as usize) };
                 let norm_type = match l {
                     MatrixLayout::C { .. } => NormType::Infinity,
                     MatrixLayout::F { .. } => NormType::One,

--- a/lax/src/solve.rs
+++ b/lax/src/solve.rs
@@ -1,7 +1,6 @@
 //! Solve linear problem using LU decomposition
 
-use super::*;
-use crate::{error::*, layout::MatrixLayout};
+use crate::{error::*, layout::MatrixLayout, *};
 use cauchy::*;
 use num_traits::{ToPrimitive, Zero};
 
@@ -34,7 +33,7 @@ macro_rules! impl_solve {
                     return Ok(Vec::new());
                 }
                 let k = ::std::cmp::min(row, col);
-                let mut ipiv = vec![0; k as usize];
+                let mut ipiv = unsafe { vec_uninit(k as usize) };
                 let mut info = 0;
                 unsafe { $getrf(l.lda(), l.len(), a, l.lda(), &mut ipiv, &mut info) };
                 info.as_lapack_result()?;
@@ -52,7 +51,7 @@ macro_rules! impl_solve {
 
                 // actual
                 let lwork = work_size[0].to_usize().unwrap();
-                let mut work = vec![Self::zero(); lwork];
+                let mut work = unsafe { vec_uninit(lwork) };
                 unsafe {
                     $getri(
                         l.len(),

--- a/lax/src/svd.rs
+++ b/lax/src/svd.rs
@@ -1,6 +1,6 @@
 //! Singular-value decomposition
 
-use crate::{error::*, layout::MatrixLayout};
+use crate::{error::*, layout::MatrixLayout, *};
 use cauchy::*;
 use num_traits::{ToPrimitive, Zero};
 
@@ -61,21 +61,21 @@ macro_rules! impl_svd {
 
                 let m = l.lda();
                 let mut u = match ju {
-                    FlagSVD::All => Some(vec![Self::zero(); (m * m) as usize]),
+                    FlagSVD::All => Some(unsafe { vec_uninit( (m * m) as usize) }),
                     FlagSVD::No => None,
                 };
 
                 let n = l.len();
                 let mut vt = match jvt {
-                    FlagSVD::All => Some(vec![Self::zero(); (n * n) as usize]),
+                    FlagSVD::All => Some(unsafe { vec_uninit( (n * n) as usize) }),
                     FlagSVD::No => None,
                 };
 
                 let k = std::cmp::min(m, n);
-                let mut s = vec![Self::Real::zero(); k as usize];
+                let mut s = unsafe { vec_uninit( k as usize) };
 
                 $(
-                let mut $rwork_ident = vec![Self::Real::zero(); 5 * k as usize];
+                let mut $rwork_ident = unsafe { vec_uninit( 5 * k as usize) };
                 )*
 
                 // eval work size
@@ -104,7 +104,7 @@ macro_rules! impl_svd {
 
                 // calc
                 let lwork = work_size[0].to_usize().unwrap();
-                let mut work = vec![Self::zero(); lwork];
+                let mut work = unsafe { vec_uninit( lwork) };
                 unsafe {
                     $gesvd(
                         ju as u8,

--- a/lax/src/svddc.rs
+++ b/lax/src/svddc.rs
@@ -1,5 +1,4 @@
-use super::*;
-use crate::{error::*, layout::MatrixLayout};
+use crate::{error::*, layout::MatrixLayout, *};
 use cauchy::*;
 use num_traits::{ToPrimitive, Zero};
 
@@ -34,7 +33,7 @@ macro_rules! impl_svddc {
                 let m = l.lda();
                 let n = l.len();
                 let k = m.min(n);
-                let mut s = vec![Self::Real::zero(); k as usize];
+                let mut s = unsafe { vec_uninit( k as usize) };
 
                 let (u_col, vt_row) = match jobz {
                     UVTFlag::Full | UVTFlag::None => (m, n),
@@ -42,12 +41,12 @@ macro_rules! impl_svddc {
                 };
                 let (mut u, mut vt) = match jobz {
                     UVTFlag::Full => (
-                        Some(vec![Self::zero(); (m * m) as usize]),
-                        Some(vec![Self::zero(); (n * n) as usize]),
+                        Some(unsafe { vec_uninit( (m * m) as usize) }),
+                        Some(unsafe { vec_uninit( (n * n) as usize) }),
                     ),
                     UVTFlag::Some => (
-                        Some(vec![Self::zero(); (m * u_col) as usize]),
-                        Some(vec![Self::zero(); (n * vt_row) as usize]),
+                        Some(unsafe { vec_uninit( (m * u_col) as usize) }),
+                        Some(unsafe { vec_uninit( (n * vt_row) as usize) }),
                     ),
                     UVTFlag::None => (None, None),
                 };
@@ -59,12 +58,12 @@ macro_rules! impl_svddc {
                     UVTFlag::None => 7 * mn,
                     _ => std::cmp::max(5*mn*mn + 5*mn, 2*mx*mn + 2*mn*mn + mn),
                 };
-                let mut $rwork_ident = vec![Self::Real::zero(); lrwork];
+                let mut $rwork_ident = unsafe { vec_uninit( lrwork) };
                 )*
 
                 // eval work size
                 let mut info = 0;
-                let mut iwork = vec![0; 8 * k as usize];
+                let mut iwork = unsafe { vec_uninit( 8 * k as usize) };
                 let mut work_size = [Self::zero()];
                 unsafe {
                     $gesdd(
@@ -89,7 +88,7 @@ macro_rules! impl_svddc {
 
                 // do svd
                 let lwork = work_size[0].to_usize().unwrap();
-                let mut work = vec![Self::zero(); lwork];
+                let mut work = unsafe { vec_uninit( lwork) };
                 unsafe {
                     $gesdd(
                         jobz as u8,

--- a/lax/src/triangular.rs
+++ b/lax/src/triangular.rs
@@ -1,9 +1,7 @@
 //! Implement linear solver and inverse matrix
 
-use super::*;
-use crate::{error::*, layout::*};
+use crate::{error::*, layout::*, *};
 use cauchy::*;
-use num_traits::Zero;
 
 #[derive(Debug, Clone, Copy)]
 #[repr(u8)]
@@ -39,7 +37,7 @@ macro_rules! impl_triangular {
                 let mut a_t = None;
                 let a_layout = match a_layout {
                     MatrixLayout::C { .. } => {
-                        a_t = Some(vec![Self::zero(); a.len()]);
+                        a_t = Some(unsafe { vec_uninit(a.len()) });
                         transpose(a_layout, a, a_t.as_mut().unwrap())
                     }
                     MatrixLayout::F { .. } => a_layout,
@@ -49,7 +47,7 @@ macro_rules! impl_triangular {
                 let mut b_t = None;
                 let b_layout = match b_layout {
                     MatrixLayout::C { .. } => {
-                        b_t = Some(vec![Self::zero(); b.len()]);
+                        b_t = Some(unsafe { vec_uninit(b.len()) });
                         transpose(b_layout, b, b_t.as_mut().unwrap())
                     }
                     MatrixLayout::F { .. } => b_layout,


### PR DESCRIPTION
Split from #241

Current implementation uses zero-initialization like

```rust
let mut work = vec![Self::zero(); n];
```

This will initialize `work` memory using `memset`, which would be fastest to initialize memory. This memory initialization make our code safe for accessing like `work[i]`, however, this is relatively heavy comparing to uninitialized code:

```rust
let mut work = Vec::with_capacity(n);
unsafe { work.set_len(n) };
```

This takes `O(1)` time while initialization needs `O(n)` time, but access `work[i]` causes undefined behavior even if `i < n`. 
Because LAPACK routines are assured not to read `work` memory, this uninitialized version can be used.

This cost is usually neglectable  comparing to most LAPACK routines, which often takes `O(n^2)` or `O(n^3)` for large `n`. But if we focus on the memory allocation cost #241 #168, it should be considered, and split them to evaluate memory allocation cost properly.

Alternative
----------------

```rust
let work = vec![std::mem::MaybeUninit::uninit(); n];
```

could be another way. It actually does not initialize the memory, and almost same performance as above uninitialized version. I do not use it on this PR because some API, especially [slice_get_mut](https://doc.rust-lang.org/std/mem/union.MaybeUninit.html#method.slice_get_mut) is not stabilized yet. This will be better choice for future rustc where they are stabilized.

Links
-------
- [Fast vector initialization without default value -- Rust Program Language Forum](https://users.rust-lang.org/t/fast-vector-initialization-without-default-value/34857)