### PR TITLE
Skip eigenvector calculation when only eigenvalues are requested

### DIFF
--- a/ndarray-linalg/src/eig.rs
+++ b/ndarray-linalg/src/eig.rs
@@ -72,7 +72,7 @@ where
 
     fn eigvals(&self) -> Result<Self::EigVal> {
         let mut a = self.to_owned();
-        let (s, _) = A::eig(true, a.square_layout()?, a.as_allocated_mut()?)?;
+        let (s, _) = A::eig(false, a.square_layout()?, a.as_allocated_mut()?)?;
         Ok(ArrayBase::from(s))
     }
 }

--- a/ndarray-linalg/src/eigh.rs
+++ b/ndarray-linalg/src/eigh.rs
@@ -189,7 +189,7 @@ where
     type EigVal = Array1<A::Real>;
 
     fn eigvalsh_inplace(&mut self, uplo: UPLO) -> Result<Self::EigVal> {
-        let s = A::eigh(true, self.square_layout()?, uplo, self.as_allocated_mut()?)?;
+        let s = A::eigh(false, self.square_layout()?, uplo, self.as_allocated_mut()?)?;
         Ok(ArrayBase::from(s))
     }
 }


### PR DESCRIPTION
This disables the eigenvector calculation when only eigenvalues are requested. From my tests this yields the same results and is much faster. (See also #255)