### PR TITLE
Cholesky factorization of PSD matrices

### DIFF
--- a/src/lapack/cholesky_semi.rs
+++ b/src/lapack/cholesky_semi.rs
@@ -1,0 +1,25 @@
+use super::*;
+use crate::{error::*, layout::*};
+
+pub fn cholesky_semi(l: MatrixLayout, uplo: UPLO, a: &mut [f64], rank: &mut i32) -> Result<Vec<i32>> {
+    let (n, _) = l.size();
+    let mut ipiv = vec![0; n as usize];
+    let tol = 1.0e-12_f64;
+    let info = unsafe {
+        lapacke::dpstrf(
+            l.lapacke_layout(),
+            uplo as u8,
+            n,
+            a,
+            l.lda(),
+            &mut ipiv,
+            rank,
+            tol,
+        )
+    };
+    if info < 0 {
+        Err(LinalgError::Lapack { return_code: info })
+    } else {
+        Ok(ipiv)
+    }
+}

--- a/src/lapack/mod.rs
+++ b/src/lapack/mod.rs
@@ -1,6 +1,7 @@
 //! Define traits wrapping LAPACK routines
 
 pub mod cholesky;
+pub mod cholesky_semi;
 pub mod eig;
 pub mod eigh;
 pub mod least_squares;
@@ -14,6 +15,7 @@ pub mod triangular;
 pub mod tridiagonal;
 
 pub use self::cholesky::*;
+pub use self::cholesky_semi::*;
 pub use self::eig::*;
 pub use self::eigh::*;
 pub use self::least_squares::*;


### PR DESCRIPTION
Very limited proof of concept PR to wrap around LAPACK's `dpstrf` and carry out the Cholesky Factorization of PSD matrices.

In its current state of `ndarray_linalg` does not handle this use case.

See this [issue](https://github.com/rust-ndarray/ndarray-linalg/issues/252) for a discussion.
Another problem is that `ndarray_linalg` will currently return errors with `solveh` when used on singular but still PSD matrices.