### PR TITLE
Bump ndarray version to 0.14

### DIFF
--- a/ndarray-linalg/Cargo.toml
+++ b/ndarray-linalg/Cargo.toml
@@ -36,7 +36,7 @@ rand = "0.5"
 thiserror = "1.0.20"
 
 [dependencies.ndarray]
-version = "0.13.0"
+version = "0.14"
 features = ["blas", "approx"]
 default-features = false
 
@@ -46,9 +46,10 @@ path = "../lax"
 default-features = false
 
 [dev-dependencies]
-paste = "0.1.9"
-criterion = "0.3.1"
-approx = { version = "0.3.2", features = ["num-complex"] }
+paste = "1.0"
+criterion = "0.3"
+# Keep the same version as ndarray's dependency!
+approx = { version = "0.4", features = ["num-complex"] }
 
 [[bench]]
 name = "truncated_eig"

--- a/ndarray-linalg/src/generate.rs
+++ b/ndarray-linalg/src/generate.rs
@@ -110,14 +110,8 @@ where
     A: Scalar,
     S: Data<Elem = A>,
 {
-    let views: Vec<_> = xs
-        .iter()
-        .map(|x| {
-            let n = x.len();
-            x.view().into_shape((n, 1)).unwrap()
-        })
-        .collect();
-    stack(Axis(1), &views).map_err(|e| e.into())
+    let views: Vec<_> = xs.iter().map(|x| x.view()).collect();
+    stack(Axis(1), &views).map_err(Into::into)
 }
 
 /// stack vectors into matrix vertically
@@ -126,12 +120,6 @@ where
     A: Scalar,
     S: Data<Elem = A>,
 {
-    let views: Vec<_> = xs
-        .iter()
-        .map(|x| {
-            let n = x.len();
-            x.view().into_shape((1, n)).unwrap()
-        })
-        .collect();
-    stack(Axis(0), &views).map_err(|e| e.into())
+    let views: Vec<_> = xs.iter().map(|x| x.view()).collect();
+    stack(Axis(0), &views).map_err(Into::into)
 }

--- a/ndarray-linalg/src/lobpcg/eig.rs
+++ b/ndarray-linalg/src/lobpcg/eig.rs
@@ -138,12 +138,11 @@ impl<A: Float + Scalar + ScalarOperand + Lapack + PartialOrd + Default> Iterator
 
                 // add the new eigenvector to the internal constrain matrix
                 let new_constraints = if let Some(ref constraints) = self.eig.constraints {
-                    let eigvecs_arr = constraints
+                    let eigvecs_arr: Vec<_> = constraints
                         .gencolumns()
                         .into_iter()
                         .chain(vecs.gencolumns().into_iter())
-                        .map(|x| x.insert_axis(Axis(1)))
-                        .collect::<Vec<_>>();
+                        .collect();
 
                     stack(Axis(1), &eigvecs_arr).unwrap()
                 } else {

--- a/ndarray-linalg/src/lobpcg/lobpcg.rs
+++ b/ndarray-linalg/src/lobpcg/lobpcg.rs
@@ -354,17 +354,17 @@ pub fn lobpcg<
                 };
 
                 sorted_eig(
-                    stack![
+                    concatenate![
                         Axis(0),
-                        stack![Axis(1), xax, xar, xap],
-                        stack![Axis(1), xar.t(), rar, rap],
-                        stack![Axis(1), xap.t(), rap.t(), pap]
+                        concatenate![Axis(1), xax, xar, xap],
+                        concatenate![Axis(1), xar.t(), rar, rap],
+                        concatenate![Axis(1), xap.t(), rap.t(), pap]
                     ],
-                    Some(stack![
+                    Some(concatenate![
                         Axis(0),
-                        stack![Axis(1), xx, xr, xp],
-                        stack![Axis(1), xr.t(), rr, rp],
-                        stack![Axis(1), xp.t(), rp.t(), pp]
+                        concatenate![Axis(1), xx, xr, xp],
+                        concatenate![Axis(1), xr.t(), rr, rp],
+                        concatenate![Axis(1), xp.t(), rp.t(), pp]
                     ]),
                     size_x,
                     &order,
@@ -374,15 +374,15 @@ pub fn lobpcg<
                 p_ap = None;
 
                 sorted_eig(
-                    stack![
+                    concatenate![
                         Axis(0),
-                        stack![Axis(1), xax, xar],
-                        stack![Axis(1), xar.t(), rar]
+                        concatenate![Axis(1), xax, xar],
+                        concatenate![Axis(1), xar.t(), rar]
                     ],
-                    Some(stack![
+                    Some(concatenate![
                         Axis(0),
-                        stack![Axis(1), xx, xr],
-                        stack![Axis(1), xr.t(), rr]
+                        concatenate![Axis(1), xx, xr],
+                        concatenate![Axis(1), xr.t(), rr]
                     ]),
                     size_x,
                     &order,


### PR DESCRIPTION
A breaking change happens: stack is now similar to `np.stack`, and the old stack is renamed by `concatenate`.
See https://github.com/rust-ndarray/ndarray/blob/master/RELEASES.md#api-changes for more.
Also, could you please consider releasing 0.13 with this change?