### PR TITLE
Make trace() require square matrix independent of layout

### DIFF
--- a/ndarray-linalg/src/trace.rs
+++ b/ndarray-linalg/src/trace.rs
@@ -4,7 +4,6 @@ use ndarray::*;
 use std::iter::Sum;
 
 use super::error::*;
-use super::layout::*;
 use super::types::*;
 
 pub trait Trace {
@@ -20,7 +19,13 @@ where
     type Output = A;
 
     fn trace(&self) -> Result<Self::Output> {
-        let (n, _) = self.square_layout()?.size();
+        let n = match self.is_square() {
+            true => Ok(self.nrows()),
+            false => Err(LinalgError::NotSquare {
+                rows: self.nrows() as i32,
+                cols: self.ncols() as i32,
+            }),
+        }?;
         Ok((0..n as usize).map(|i| self[(i, i)]).sum())
     }
 }


### PR DESCRIPTION
The trace of a matrix can only be computed for square matrices.  The implementation of `ndarray_linalg::trace::Trace::trace()` calls `ndarray_linalg::layout::AllocatedArray::square_layout()` to verify the matrix is square, but this call also requires the matrix layout to be contiguous.  Calling trace on an array view or slice that is not laid out contiguously in memory will generate an `ndarray_linalg::error::LinalgError::InvalidStride`.

This commit uses `ndarray::ArrayBase::is_square()` to check that the matrix is square independent of layout.