### PR TITLE
Support ndarray 0.15

### DIFF
--- a/.github/workflows/intel-mkl.yml
+++ b/.github/workflows/intel-mkl.yml
@@ -34,7 +34,7 @@ jobs:
 
   linux-container:
     runs-on: ubuntu-18.04
-    container: rustmath/mkl-rust:1.43.0
+    container: rustmath/mkl-rust:1.49.0
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/cargo@v1

--- a/ndarray-linalg/Cargo.toml
+++ b/ndarray-linalg/Cargo.toml
@@ -36,8 +36,8 @@ rand = "0.7.3"
 thiserror = "1.0.20"
 
 [dependencies.ndarray]
-version = "0.14"
-features = ["blas", "approx"]
+version = ">=0.14,<0.16"
+features = ["blas", "approx", "std"]
 default-features = false
 
 [dependencies.lax]

--- a/ndarray-linalg/src/cholesky.rs
+++ b/ndarray-linalg/src/cholesky.rs
@@ -26,7 +26,7 @@
 //!
 //! // Obtain `L`
 //! let lower = a.cholesky(UPLO::Lower).unwrap();
-//! assert!(lower.all_close(&array![
+//! assert!(lower.abs_diff_eq(&array![
 //!     [ 2., 0., 0.],
 //!     [ 6., 1., 0.],
 //!     [-8., 5., 3.]
@@ -39,7 +39,7 @@
 //! // Solve `A * x = b`
 //! let b = array![4., 13., -11.];
 //! let x = a.solvec(&b).unwrap();
-//! assert!(x.all_close(&array![-2., 1., 0.], 1e-9));
+//! assert!(x.abs_diff_eq(&array![-2., 1., 0.], 1e-9));
 //! # }
 //! ```
 

--- a/ndarray-linalg/src/solve.rs
+++ b/ndarray-linalg/src/solve.rs
@@ -16,7 +16,7 @@
 //! let a: Array2<f64> = array![[3., 2., -1.], [2., -2., 4.], [-2., 1., -2.]];
 //! let b: Array1<f64> = array![1., -2., 0.];
 //! let x = a.solve_into(b).unwrap();
-//! assert!(x.all_close(&array![1., -2., -2.], 1e-9));
+//! assert!(x.abs_diff_eq(&array![1., -2., -2.], 1e-9));
 //!
 //! # }
 //! ```

--- a/ndarray-linalg/src/solveh.rs
+++ b/ndarray-linalg/src/solveh.rs
@@ -23,7 +23,7 @@
 //! ];
 //! let b: Array1<f64> = array![11., -12., 1.];
 //! let x = a.solveh_into(b).unwrap();
-//! assert!(x.all_close(&array![1., 3., -2.], 1e-9));
+//! assert!(x.abs_diff_eq(&array![1., 3., -2.], 1e-9));
 //!
 //! # }
 //! ```


### PR DESCRIPTION
Adding `std` feature is required since ndarray 0.15 made
`impl std::error::Error for ShapeError` require std.