### PR TITLE
Make lobpcg::MagnitudeCorrection public and improve documentation

### DIFF
--- a/ndarray-linalg/Cargo.toml
+++ b/ndarray-linalg/Cargo.toml
@@ -50,8 +50,8 @@ paste = "1.0.5"
 criterion = "0.3.4"
 # Keep the same version as ndarray's dependency!
 approx = { version = "0.4", features = ["num-complex"] }
-rand_xoshiro = "0.4"
-ndarray-rand = "0.12"
+rand_xoshiro = "0.6"
+ndarray-rand = "0.14"
 
 [[bench]]
 name = "truncated_eig"

--- a/ndarray-linalg/Cargo.toml
+++ b/ndarray-linalg/Cargo.toml
@@ -50,6 +50,7 @@ paste = "1.0"
 criterion = "0.3"
 # Keep the same version as ndarray's dependency!
 approx = { version = "0.4", features = ["num-complex"] }
+rand_xoshiro = "0.6"
 
 [[bench]]
 name = "truncated_eig"

--- a/ndarray-linalg/Cargo.toml
+++ b/ndarray-linalg/Cargo.toml
@@ -50,7 +50,8 @@ paste = "1.0"
 criterion = "0.3"
 # Keep the same version as ndarray's dependency!
 approx = { version = "0.4", features = ["num-complex"] }
-rand_xoshiro = "0.6"
+rand_xoshiro = "0.4"
+ndarray-rand = "0.12"
 
 [[bench]]
 name = "truncated_eig"

--- a/ndarray-linalg/src/lobpcg/eig.rs
+++ b/ndarray-linalg/src/lobpcg/eig.rs
@@ -20,14 +20,17 @@ use num_traits::{Float, NumCast};
 /// # Example
 ///
 /// ```rust
+/// use ndarray::{arr1, Array2};
+/// use ndarray_linalg::{TruncatedEig, TruncatedOrder};
+///
 /// let diag = arr1(&[1., 2., 3., 4., 5.]);
 /// let a = Array2::from_diag(&diag);
 ///
-/// let eig = TruncatedEig::new(a, Order::Largest)
+/// let eig = TruncatedEig::new(a, TruncatedOrder::Largest)
 ///    .precision(1e-5)
 ///    .maxiter(500);
 ///
-/// let res = eig.decompose();
+/// let res = eig.decompose(3);
 /// ```
 
 pub struct TruncatedEig<A: Scalar> {
@@ -109,14 +112,17 @@ impl<A: Float + Scalar + ScalarOperand + Lapack + PartialOrd + Default> Truncate
     /// # Example
     ///
     /// ```rust
+    /// use ndarray::{arr1, Array2};
+    /// use ndarray_linalg::{TruncatedEig, TruncatedOrder};
+    ///
     /// let diag = arr1(&[1., 2., 3., 4., 5.]);
     /// let a = Array2::from_diag(&diag);
     ///
-    /// let eig = TruncatedEig::new(a, Order::Largest)
+    /// let eig = TruncatedEig::new(a, TruncatedOrder::Largest)
     ///    .precision(1e-5)
     ///    .maxiter(500);
     ///
-    /// let res = eig.decompose();
+    /// let res = eig.decompose(3);
     /// ```
     pub fn decompose(&self, num: usize) -> LobpcgResult<A> {
         let x: Array2<f64> = generate::random((self.problem.len_of(Axis(0)), num));
@@ -169,15 +175,21 @@ impl<A: Float + Scalar + ScalarOperand + Lapack + PartialOrd + Default> IntoIter
 /// # Example
 ///
 /// ```rust
-/// let teig = TruncatedEig::new(a, Order::Largest)
+/// use ndarray::{arr1, Array2};
+/// use ndarray_linalg::{TruncatedEig, TruncatedOrder};
+///
+/// let diag = arr1(&[1., 2., 3., 4., 5.]);
+/// let a = Array2::from_diag(&diag);
+///
+/// let teig = TruncatedEig::new(a, TruncatedOrder::Largest)
 ///     .precision(1e-5)
 ///     .maxiter(500);
 /// 
 /// // solve eigenproblem until eigenvalues get smaller than 0.5
 /// let res = teig.into_iter()
 ///     .take_while(|x| x.0[0] > 0.5)
-///     .flat_map(|x| x.0)
-///     .collect();
+///     .flat_map(|x| x.0.to_vec())
+///     .collect::<Vec<_>>();
 /// ```
 pub struct TruncatedEigIterator<A: Scalar> {
     step_size: usize,

--- a/ndarray-linalg/src/lobpcg/eig.rs
+++ b/ndarray-linalg/src/lobpcg/eig.rs
@@ -75,7 +75,7 @@ impl<A: Float + Scalar + ScalarOperand + Lapack + PartialOrd + Default> Truncate
 
     /// Set the maximal number of iterations
     ///
-    /// The LOBPCG is an iterative approach to eigenproblems and stops when this maximum 
+    /// The LOBPCG is an iterative approach to eigenproblems and stops when this maximum
     /// number of iterations are reached.
     pub fn maxiter(mut self, maxiter: usize) -> Self {
         self.maxiter = maxiter;
@@ -184,7 +184,7 @@ impl<A: Float + Scalar + ScalarOperand + Lapack + PartialOrd + Default> IntoIter
 /// let teig = TruncatedEig::new(a, TruncatedOrder::Largest)
 ///     .precision(1e-5)
 ///     .maxiter(500);
-/// 
+///
 /// // solve eigenproblem until eigenvalues get smaller than 0.5
 /// let res = teig.into_iter()
 ///     .take_while(|x| x.0[0] > 0.5)

--- a/ndarray-linalg/src/lobpcg/eig.rs
+++ b/ndarray-linalg/src/lobpcg/eig.rs
@@ -1,9 +1,10 @@
+//! Truncated eigenvalue decomposition
+//!
+
 use super::lobpcg::{lobpcg, LobpcgResult, Order};
 use crate::{generate, Scalar};
 use lax::Lapack;
 
-///! Implements truncated eigenvalue decomposition
-///
 use ndarray::prelude::*;
 use ndarray::stack;
 use ndarray::ScalarOperand;
@@ -15,6 +16,20 @@ use num_traits::{Float, NumCast};
 /// parameter like maximal iteration, precision and constraint matrix. Furthermore it allows
 /// conversion into a iterative solver where each iteration step yields a new eigenvalue/vector
 /// pair.
+///
+/// # Example
+///
+/// ```rust
+/// let diag = arr1(&[1., 2., 3., 4., 5.]);
+/// let a = Array2::from_diag(&diag);
+///
+/// let eig = TruncatedEig::new(a, Order::Largest)
+///    .precision(1e-5)
+///    .maxiter(500);
+///
+/// let res = eig.decompose();
+/// ```
+
 pub struct TruncatedEig<A: Scalar> {
     order: Order,
     problem: Array2<A>,
@@ -25,6 +40,11 @@ pub struct TruncatedEig<A: Scalar> {
 }
 
 impl<A: Float + Scalar + ScalarOperand + Lapack + PartialOrd + Default> TruncatedEig<A> {
+    /// Create a new truncated eigenproblem solver
+    ///
+    /// # Properties
+    /// * `problem`: problem matrix
+    /// * `order`: ordering of the eigenvalues with [TruncatedOrder](crate::TruncatedOrder)
     pub fn new(problem: Array2<A>, order: Order) -> TruncatedEig<A> {
         TruncatedEig {
             precision: 1e-5,
@@ -36,31 +56,68 @@ impl<A: Float + Scalar + ScalarOperand + Lapack + PartialOrd + Default> Truncate
         }
     }
 
+    /// Set desired precision
+    ///
+    /// This argument specifies the desired precision, which is passed to the LOBPCG solver. It
+    /// controls at which point the opimization of each eigenvalue is stopped. The precision is
+    /// global and applied to all eigenvalues with respect to their L2 norm.
+    ///
+    /// If the precision can't be reached and the maximum number of iteration is reached, then an
+    /// error is returned in [LobpcgResult](crate::lobpcg::LobpcgResult).
     pub fn precision(mut self, precision: f32) -> Self {
         self.precision = precision;
 
         self
     }
 
+    /// Set the maximal number of iterations
+    ///
+    /// The LOBPCG is an iterative approach to eigenproblems and stops when this maximum 
+    /// number of iterations are reached.
     pub fn maxiter(mut self, maxiter: usize) -> Self {
         self.maxiter = maxiter;
 
         self
     }
 
+    /// Construct a solution, which is orthogonal to this
+    ///
+    /// If a number of eigenvectors are already known, then this function can be used to construct
+    /// a orthogonal subspace. Also used with an iterative approach.
     pub fn orthogonal_to(mut self, constraints: Array2<A>) -> Self {
         self.constraints = Some(constraints);
 
         self
     }
 
+    /// Apply a preconditioner
+    ///
+    /// A preconditioning matrix can speed up the solving process by improving the spectral
+    /// distribution of the eigenvalues. It requires prior knowledge of the problem.
     pub fn precondition_with(mut self, preconditioner: Array2<A>) -> Self {
         self.preconditioner = Some(preconditioner);
 
         self
     }
 
-    // calculate the eigenvalues decompose
+    /// Calculate the eigenvalue decomposition
+    ///
+    /// # Parameters
+    ///
+    ///  * `num`: number of eigenvalues ordered by magnitude
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// let diag = arr1(&[1., 2., 3., 4., 5.]);
+    /// let a = Array2::from_diag(&diag);
+    ///
+    /// let eig = TruncatedEig::new(a, Order::Largest)
+    ///    .precision(1e-5)
+    ///    .maxiter(500);
+    ///
+    /// let res = eig.decompose();
+    /// ```
     pub fn decompose(&self, num: usize) -> LobpcgResult<A> {
         let x: Array2<f64> = generate::random((self.problem.len_of(Axis(0)), num));
         let x = x.mapv(|x| NumCast::from(x).unwrap());
@@ -104,10 +161,24 @@ impl<A: Float + Scalar + ScalarOperand + Lapack + PartialOrd + Default> IntoIter
     }
 }
 
-/// Truncate eigenproblem iterator
+/// Truncated eigenproblem iterator
 ///
 /// This wraps a truncated eigenproblem and provides an iterator where each step yields a new
 /// eigenvalue/vector pair. Useful for generating pairs until a certain condition is met.
+///
+/// # Example
+///
+/// ```rust
+/// let teig = TruncatedEig::new(a, Order::Largest)
+///     .precision(1e-5)
+///     .maxiter(500);
+/// 
+/// // solve eigenproblem until eigenvalues get smaller than 0.5
+/// let res = teig.into_iter()
+///     .take_while(|x| x.0[0] > 0.5)
+///     .flat_map(|x| x.0)
+///     .collect();
+/// ```
 pub struct TruncatedEigIterator<A: Scalar> {
     step_size: usize,
     remaining: usize,

--- a/ndarray-linalg/src/lobpcg/lobpcg.rs
+++ b/ndarray-linalg/src/lobpcg/lobpcg.rs
@@ -1,7 +1,7 @@
 ///! Locally Optimal Block Preconditioned Conjugated
 ///!
 ///! This module implements the Locally Optimal Block Preconditioned Conjugated (LOBPCG) algorithm,
-///which can be used as a solver for large symmetric positive definite eigenproblems.
+///which can be used as a solver for large symmetric eigenproblems.
 use crate::error::{LinalgError, Result};
 use crate::{cholesky::*, close_l2, eigh::*, norm::*, triangular::*};
 use cauchy::Scalar;

--- a/ndarray-linalg/src/lobpcg/mod.rs
+++ b/ndarray-linalg/src/lobpcg/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! Locally Optimal Block Preconditioned Conjugate Gradient (LOBPCG) is a matrix-free method for
 //! finding the large (or smallest) eigenvalues and the corresponding eigenvectors of a symmetric
-//! eigenvalue problem 
+//! eigenvalue problem
 //! ```
 //! A x = lambda x
 //! ```

--- a/ndarray-linalg/src/lobpcg/mod.rs
+++ b/ndarray-linalg/src/lobpcg/mod.rs
@@ -4,4 +4,4 @@ mod svd;
 
 pub use eig::{TruncatedEig, TruncatedEigIterator};
 pub use lobpcg::{lobpcg, LobpcgResult, Order as TruncatedOrder};
-pub use svd::{TruncatedSvd, MagnitudeCorrection};
+pub use svd::{MagnitudeCorrection, TruncatedSvd};

--- a/ndarray-linalg/src/lobpcg/mod.rs
+++ b/ndarray-linalg/src/lobpcg/mod.rs
@@ -3,7 +3,7 @@
 //! Locally Optimal Block Preconditioned Conjugate Gradient (LOBPCG) is a matrix-free method for
 //! finding the large (or smallest) eigenvalues and the corresponding eigenvectors of a symmetric
 //! eigenvalue problem
-//! ```
+//! ```text
 //! A x = lambda x
 //! ```
 //! where A is symmetric and (x, lambda) the solution. It has the following advantages:

--- a/ndarray-linalg/src/lobpcg/mod.rs
+++ b/ndarray-linalg/src/lobpcg/mod.rs
@@ -1,3 +1,19 @@
+//! Decomposition with LOBPCG
+//!
+//! Locally Optimal Block Preconditioned Conjugate Gradient (LOBPCG) is a matrix-free method for
+//! finding the large (or smallest) eigenvalues and the corresponding eigenvectors of a symmetric
+//! eigenvalue problem 
+//! ```
+//! A x = lambda x
+//! ```
+//! where A is symmetric and (x, lambda) the solution. It has the following advantages:
+//! * matrix free: does not require storing the coefficient matrix explicitely and only evaluates
+//! matrix-vector products.
+//! * factorization-free: does not require any matrix decomposition
+//! * linear-convergence: theoretically guaranteed and practically observed
+//!
+//! See also the wikipedia article at [LOBPCG](https://en.wikipedia.org/wiki/LOBPCG)
+//!
 mod eig;
 mod lobpcg;
 mod svd;

--- a/ndarray-linalg/src/lobpcg/mod.rs
+++ b/ndarray-linalg/src/lobpcg/mod.rs
@@ -2,6 +2,6 @@ mod eig;
 mod lobpcg;
 mod svd;
 
-pub use eig::TruncatedEig;
+pub use eig::{TruncatedEig, TruncatedEigIterator};
 pub use lobpcg::{lobpcg, LobpcgResult, Order as TruncatedOrder};
-pub use svd::TruncatedSvd;
+pub use svd::{TruncatedSvd, MagnitudeCorrection};

--- a/ndarray-linalg/src/lobpcg/svd.rs
+++ b/ndarray-linalg/src/lobpcg/svd.rs
@@ -90,7 +90,7 @@ impl<A: Float + PartialOrd + DivAssign<A> + 'static + MagnitudeCorrection> Trunc
 /// Truncated singular value decomposition
 ///
 /// Wraps the LOBPCG algorithm and provides convenient builder-pattern access to
-/// parameter like maximal iteration, precision and contrain matrix. 
+/// parameter like maximal iteration, precision and contrain matrix.
 pub struct TruncatedSvd<A: Scalar> {
     order: Order,
     problem: Array2<A>,

--- a/ndarray-linalg/src/lobpcg/svd.rs
+++ b/ndarray-linalg/src/lobpcg/svd.rs
@@ -200,10 +200,10 @@ mod tests {
     use super::TruncatedSvd;
     use crate::{close_l2, generate};
 
-    use rand::SeedableRng;
-    use rand_xoshiro::Xoshiro256Plus;
     use ndarray::{arr1, arr2, Array1, Array2};
     use ndarray_rand::{rand_distr::StandardNormal, RandomExt};
+    use rand::SeedableRng;
+    use rand_xoshiro::Xoshiro256Plus;
 
     use approx::assert_abs_diff_eq;
 
@@ -239,12 +239,12 @@ mod tests {
     }
 
     /// Eigenvalue structure in high dimensions
-    /// 
+    ///
     /// This test checks that the eigenvalues are following the Marchensko-Pastur law. The data is
     /// standard uniformly distributed (i.e. E(x) = 0, E^2(x) = 1) and we have twice the amount of
     /// data when compared to features. The probability density of the eigenvalues should then follow
     /// a special densitiy function, described by the Marchenko-Pastur law.
-    /// 
+    ///
     /// See also https://en.wikipedia.org/wiki/Marchenko%E2%80%93Pastur_distribution
     #[test]
     fn test_marchenko_pastur() {
@@ -258,14 +258,14 @@ mod tests {
             .decompose(500)
             .unwrap();
 
-        let sv = res.values().mapv(|x: f64| x*x);
+        let sv = res.values().mapv(|x: f64| x * x);
 
         // we have created a random spectrum and can apply the Marchenko-Pastur law
         // with variance 1 and p/n = 0.5
-        let (a, b) = ( 
+        let (a, b) = (
             1. * (1. - 0.5f64.sqrt()).powf(2.0),
             1. * (1. + 0.5f64.sqrt()).powf(2.0),
-        );  
+        );
 
         // check that the spectrum has correct boundaries
         assert_abs_diff_eq!(b, sv[0], epsilon = 0.1);
@@ -281,14 +281,14 @@ mod tests {
 
                 if i == sv.len() {
                     break 'outer;
-                }   
-            }   
+                }
+            }
 
             let x = th + 0.05;
             let mp_law = ((b - x) * (x - a)).sqrt() / std::f64::consts::PI / x;
             let empirical = count as f64 / 500. / ((2.8 - 0.1) / 28.);
 
             assert_abs_diff_eq!(mp_law, empirical, epsilon = 0.05);
-        }   
-    } 
+        }
+    }
 }

--- a/ndarray-linalg/src/lobpcg/svd.rs
+++ b/ndarray-linalg/src/lobpcg/svd.rs
@@ -24,7 +24,7 @@ pub struct TruncatedSvdResult<A> {
 }
 
 impl<A: Float + PartialOrd + DivAssign<A> + 'static + MagnitudeCorrection> TruncatedSvdResult<A> {
-    /// Returns singular values ordered by magnitude with indices.
+    /// Returns singular values ordered by magnitude with indices
     fn singular_values_with_indices(&self) -> (Array1<A>, Vec<usize>) {
         // numerate eigenvalues
         let mut a = self.eigvals.iter().enumerate().collect::<Vec<_>>();
@@ -90,7 +90,7 @@ impl<A: Float + PartialOrd + DivAssign<A> + 'static + MagnitudeCorrection> Trunc
 /// Truncated singular value decomposition
 ///
 /// Wraps the LOBPCG algorithm and provides convenient builder-pattern access to
-/// parameter like maximal iteration, precision and constraint matrix.
+/// parameter like maximal iteration, precision and contrain matrix. 
 pub struct TruncatedSvd<A: Scalar> {
     order: Order,
     problem: Array2<A>,
@@ -99,6 +99,11 @@ pub struct TruncatedSvd<A: Scalar> {
 }
 
 impl<A: Float + Scalar + ScalarOperand + Lapack + PartialOrd + Default> TruncatedSvd<A> {
+    /// Create a new truncated SVD problem
+    ///
+    /// # Parameters
+    ///  * `problem`: rectangular matrix which is decomposed
+    ///  * `order`: whether to return large or small (close to zero) singular values
     pub fn new(problem: Array2<A>, order: Order) -> TruncatedSvd<A> {
         TruncatedSvd {
             precision: 1e-5,
@@ -108,19 +113,48 @@ impl<A: Float + Scalar + ScalarOperand + Lapack + PartialOrd + Default> Truncate
         }
     }
 
+    /// Set the required precision of the solution
+    ///
+    /// The precision is, in the context of SVD, the square-root precision of the underlying
+    /// eigenproblem solution. The eigenproblem-precision is used to check the L2 error of each
+    /// eigenvector and stops its optimization when the required precision is reached.
     pub fn precision(mut self, precision: f32) -> Self {
         self.precision = precision;
 
         self
     }
 
+    /// Set the maximal number of iterations
+    ///
+    /// The LOBPCG is an iterative approach to eigenproblems and stops when this maximum
+    /// number of iterations are reached.
     pub fn maxiter(mut self, maxiter: usize) -> Self {
         self.maxiter = maxiter;
 
         self
     }
 
-    // calculate the eigenvalue decomposition
+    /// Calculate the singular value decomposition
+    ///
+    /// # Parameters
+    ///
+    ///  * `num`: number of singular-value/vector pairs, ordered by magnitude
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use ndarray::{arr1, Array2};
+    /// use ndarray_linalg::{TruncatedSvd, TruncatedOrder};
+    ///
+    /// let diag = arr1(&[1., 2., 3., 4., 5.]);
+    /// let a = Array2::from_diag(&diag);
+    ///
+    /// let eig = TruncatedSvd::new(a, TruncatedOrder::Largest)
+    ///    .precision(1e-5)
+    ///    .maxiter(500);
+    ///
+    /// let res = eig.decompose(3);
+    /// ```
     pub fn decompose(self, num: usize) -> Result<TruncatedSvdResult<A>> {
         if num < 1 {
             panic!("The number of singular values to compute should be larger than zero!");


### PR DESCRIPTION
Document the lobpcg module, fixes #274:
 * [x] Make `MagnitudeCorrection` public
 * [x] Improve documentation for `TruncatedEig`
 * [x] Improve documentation for `TruncatedSvd`
 * [x] Add Marchensko-Pastur law test