### PR TITLE
Avoid unnecessary calculation of eigenvectors in EigVals::eigvals and relax the DataMut bound

### DIFF
--- a/ndarray-linalg/src/eig.rs
+++ b/ndarray-linalg/src/eig.rs
@@ -66,7 +66,7 @@ pub trait EigVals {
 impl<A, S> EigVals for ArrayBase<S, Ix2>
 where
     A: Scalar + Lapack,
-    S: DataMut<Elem = A>,
+    S: Data<Elem = A>,
 {
     type EigVal = Array1<A::Complex>;
 

--- a/ndarray-linalg/src/eig.rs
+++ b/ndarray-linalg/src/eig.rs
@@ -72,7 +72,7 @@ where
 
     fn eigvals(&self) -> Result<Self::EigVal> {
         let mut a = self.to_owned();
-        let (s, _) = A::eig(true, a.square_layout()?, a.as_allocated_mut()?)?;
+        let (s, _) = A::eig(false, a.square_layout()?, a.as_allocated_mut()?)?;
         Ok(ArrayBase::from(s))
     }
 }

--- a/ndarray-linalg/tests/eig.rs
+++ b/ndarray-linalg/tests/eig.rs
@@ -2,8 +2,11 @@ use ndarray::*;
 use ndarray_linalg::*;
 
 // Test Av_i = e_i v_i for i = 0..n
-fn test_eig<T: Scalar>(a: Array2<T>, eigs: Array1<T::Complex>, vecs: Array2<T::Complex>)
-where
+fn test_eig<T: Scalar>(
+    a: ArrayView2<'_, T>,
+    eigs: ArrayView1<'_, T::Complex>,
+    vecs: ArrayView2<'_, T::Complex>,
+) where
     T::Complex: Lapack,
 {
     println!("a\n{:+.4}", &a);
@@ -205,29 +208,37 @@ macro_rules! impl_test_real {
             #[test]
             fn [<$real _eigvals >]() {
                 let a = test_matrix_real::<$real>();
-                let (e, _vecs) = a.eig().unwrap();
-                assert_close_l2!(&e, &answer_eig_real::<$real>(), 1.0e-3);
+                let (e1, _vecs) = a.eig().unwrap();
+                let e2 = a.eigvals().unwrap();
+                assert_close_l2!(&e1, &answer_eig_real::<$real>(), 1.0e-3);
+                assert_close_l2!(&e2, &answer_eig_real::<$real>(), 1.0e-3);
             }
 
             #[test]
             fn [<$real _eigvals_t>]() {
                 let a = test_matrix_real_t::<$real>();
-                let (e, _vecs) = a.eig().unwrap();
-                assert_close_l2!(&e, &answer_eig_real::<$real>(), 1.0e-3);
+                let (e1, _vecs) = a.eig().unwrap();
+                let e2 = a.eigvals().unwrap();
+                assert_close_l2!(&e1, &answer_eig_real::<$real>(), 1.0e-3);
+                assert_close_l2!(&e2, &answer_eig_real::<$real>(), 1.0e-3);
             }
 
             #[test]
             fn [<$real _eig>]() {
                 let a = test_matrix_real::<$real>();
-                let (e, vecs) = a.eig().unwrap();
-                test_eig(a, e, vecs);
+                let (e1, vecs) = a.eig().unwrap();
+                let e2 = a.eigvals().unwrap();
+                test_eig(a.view(), e1.view(), vecs.view());
+                test_eig(a.view(), e2.view(), vecs.view());
             }
 
             #[test]
             fn [<$real _eig_t>]() {
                 let a = test_matrix_real_t::<$real>();
-                let (e, vecs) = a.eig().unwrap();
-                test_eig(a, e, vecs);
+                let (e1, vecs) = a.eig().unwrap();
+                let e2 = a.eigvals().unwrap();
+                test_eig(a.view(), e1.view(), vecs.view());
+                test_eig(a.view(), e2.view(), vecs.view());
             }
 
         } // paste::item!
@@ -243,15 +254,19 @@ macro_rules! impl_test_complex {
             #[test]
             fn [<$complex _eigvals >]() {
                 let a = test_matrix_complex::<$complex>();
-                let (e, _vecs) = a.eig().unwrap();
-                assert_close_l2!(&e, &answer_eig_complex::<$complex>(), 1.0e-3);
+                let (e1, _vecs) = a.eig().unwrap();
+                let e2 = a.eigvals().unwrap();
+                assert_close_l2!(&e1, &answer_eig_complex::<$complex>(), 1.0e-3);
+                assert_close_l2!(&e2, &answer_eig_complex::<$complex>(), 1.0e-3);
             }
 
             #[test]
             fn [<$complex _eigvals_t>]() {
                 let a = test_matrix_complex_t::<$complex>();
-                let (e, _vecs) = a.eig().unwrap();
-                assert_close_l2!(&e, &answer_eig_complex::<$complex>(), 1.0e-3);
+                let (e1, _vecs) = a.eig().unwrap();
+                let e2 = a.eigvals().unwrap();
+                assert_close_l2!(&e1, &answer_eig_complex::<$complex>(), 1.0e-3);
+                assert_close_l2!(&e2, &answer_eig_complex::<$complex>(), 1.0e-3);
             }
 
             #[test]
@@ -271,15 +286,19 @@ macro_rules! impl_test_complex {
             #[test]
             fn [<$complex _eig>]() {
                 let a = test_matrix_complex::<$complex>();
-                let (e, vecs) = a.eig().unwrap();
-                test_eig(a, e, vecs);
+                let (e1, vecs) = a.eig().unwrap();
+                let e2 = a.eigvals().unwrap();
+                test_eig(a.view(), e1.view(), vecs.view());
+                test_eig(a.view(), e2.view(), vecs.view());
             }
 
             #[test]
             fn [<$complex _eig_t>]() {
                 let a = test_matrix_complex_t::<$complex>();
-                let (e, vecs) = a.eig().unwrap();
-                test_eig(a, e, vecs);
+                let (e1, vecs) = a.eig().unwrap();
+                let e2 = a.eigvals().unwrap();
+                test_eig(a.view(), e1.view(), vecs.view());
+                test_eig(a.view(), e2.view(), vecs.view());
             }
         } // paste::item!
     };


### PR DESCRIPTION
This PR does the following:

- Changes `EigVals::eigvals` to not calculate the eigenvectors.
- Relaxes the bound on `EigVals` from `DataMut` to `Data`.
- Adds calls to `.eigvals()` in the tests.