### PR TITLE
Fix Solve::solve_h_* for complex inputs with standard layout

### DIFF
--- a/ndarray-linalg/tests/solve.rs
+++ b/ndarray-linalg/tests/solve.rs
@@ -1,42 +1,188 @@
-use ndarray::*;
-use ndarray_linalg::*;
+use ndarray::prelude::*;
+use ndarray_linalg::{
+    assert_aclose, assert_close_l2, c32, c64, random, random_hpd, solve::*, OperationNorm, Scalar,
+};
 
-#[test]
-fn solve_random() {
-    let a: Array2<f64> = random((3, 3));
-    let x: Array1<f64> = random(3);
-    let b = a.dot(&x);
-    let y = a.solve_into(b).unwrap();
-    assert_close_l2!(&x, &y, 1e-7);
+macro_rules! test_solve {
+    (
+        [$($elem_type:ty => $rtol:expr),*],
+        $a_ident:ident = $a:expr,
+        $x_ident:ident = $x:expr,
+        b = $b:expr,
+        $solve:ident,
+    ) => {
+        $({
+            let $a_ident: Array2<$elem_type> = $a;
+            let $x_ident: Array1<$elem_type> = $x;
+            let b: Array1<$elem_type> = $b;
+            let a = $a_ident;
+            let x = $x_ident;
+            let rtol = $rtol;
+            assert_close_l2!(&a.$solve(&b).unwrap(), &x, rtol);
+            assert_close_l2!(&a.factorize().unwrap().$solve(&b).unwrap(), &x, rtol);
+            assert_close_l2!(&a.factorize_into().unwrap().$solve(&b).unwrap(), &x, rtol);
+        })*
+    };
+}
+
+macro_rules! test_solve_into {
+    (
+        [$($elem_type:ty => $rtol:expr),*],
+        $a_ident:ident = $a:expr,
+        $x_ident:ident = $x:expr,
+        b = $b:expr,
+        $solve_into:ident,
+    ) => {
+        $({
+            let $a_ident: Array2<$elem_type> = $a;
+            let $x_ident: Array1<$elem_type> = $x;
+            let b: Array1<$elem_type> = $b;
+            let a = $a_ident;
+            let x = $x_ident;
+            let rtol = $rtol;
+            assert_close_l2!(&a.$solve_into(b.clone()).unwrap(), &x, rtol);
+            assert_close_l2!(&a.factorize().unwrap().$solve_into(b.clone()).unwrap(), &x, rtol);
+            assert_close_l2!(&a.factorize_into().unwrap().$solve_into(b.clone()).unwrap(), &x, rtol);
+        })*
+    };
+}
+
+macro_rules! test_solve_inplace {
+    (
+        [$($elem_type:ty => $rtol:expr),*],
+        $a_ident:ident = $a:expr,
+        $x_ident:ident = $x:expr,
+        b = $b:expr,
+        $solve_inplace:ident,
+    ) => {
+        $({
+            let $a_ident: Array2<$elem_type> = $a;
+            let $x_ident: Array1<$elem_type> = $x;
+            let b: Array1<$elem_type> = $b;
+            let a = $a_ident;
+            let x = $x_ident;
+            let rtol = $rtol;
+            {
+                let mut b = b.clone();
+                assert_close_l2!(&a.$solve_inplace(&mut b).unwrap(), &x, rtol);
+                assert_close_l2!(&b, &x, rtol);
+            }
+            {
+                let mut b = b.clone();
+                assert_close_l2!(&a.factorize().unwrap().$solve_inplace(&mut b).unwrap(), &x, rtol);
+                assert_close_l2!(&b, &x, rtol);
+            }
+            {
+                let mut b = b.clone();
+                assert_close_l2!(&a.factorize_into().unwrap().$solve_inplace(&mut b).unwrap(), &x, rtol);
+                assert_close_l2!(&b, &x, rtol);
+            }
+        })*
+    };
+}
+
+macro_rules! test_solve_all {
+    (
+        [$($elem_type:ty => $rtol:expr),*],
+        $a_ident:ident = $a:expr,
+        $x_ident:ident = $x:expr,
+        b = $b:expr,
+        [$solve:ident, $solve_into:ident, $solve_inplace:ident],
+    ) => {
+        test_solve!([$($elem_type => $rtol),*], $a_ident = $a, $x_ident = $x, b = $b, $solve,);
+        test_solve_into!([$($elem_type => $rtol),*], $a_ident = $a, $x_ident = $x, b = $b, $solve_into,);
+        test_solve_inplace!([$($elem_type => $rtol),*], $a_ident = $a, $x_ident = $x, b = $b, $solve_inplace,);
+    };
 }
 
 #[test]
-fn solve_random_t() {
-    let a: Array2<f64> = random((3, 3).f());
-    let x: Array1<f64> = random(3);
-    let b = a.dot(&x);
-    let y = a.solve_into(b).unwrap();
-    assert_close_l2!(&x, &y, 1e-7);
+fn solve_random_float() {
+    for n in 0..=8 {
+        for &set_f in &[false, true] {
+            test_solve_all!(
+                [f32 => 1e-3, f64 => 1e-9],
+                a = random([n; 2].set_f(set_f)),
+                x = random(n),
+                b = a.dot(&x),
+                [solve, solve_into, solve_inplace],
+            );
+        }
+    }
 }
 
 #[test]
-fn solve_factorized() {
-    let a: Array2<f64> = random((3, 3));
-    let ans: Array1<f64> = random(3);
-    let b = a.dot(&ans);
-    let f = a.factorize_into().unwrap();
-    let x = f.solve_into(b).unwrap();
-    assert_close_l2!(&x, &ans, 1e-7);
+fn solve_random_complex() {
+    for n in 0..=8 {
+        for &set_f in &[false, true] {
+            test_solve_all!(
+                [c32 => 1e-3, c64 => 1e-9],
+                a = random([n; 2].set_f(set_f)),
+                x = random(n),
+                b = a.dot(&x),
+                [solve, solve_into, solve_inplace],
+            );
+        }
+    }
 }
 
 #[test]
-fn solve_factorized_t() {
-    let a: Array2<f64> = random((3, 3).f());
-    let ans: Array1<f64> = random(3);
-    let b = a.dot(&ans);
-    let f = a.factorize_into().unwrap();
-    let x = f.solve_into(b).unwrap();
-    assert_close_l2!(&x, &ans, 1e-7);
+fn solve_t_random_float() {
+    for n in 0..=8 {
+        for &set_f in &[false, true] {
+            test_solve_all!(
+                [f32 => 1e-3, f64 => 1e-9],
+                a = random([n; 2].set_f(set_f)),
+                x = random(n),
+                b = a.t().dot(&x),
+                [solve_t, solve_t_into, solve_t_inplace],
+            );
+        }
+    }
+}
+
+#[test]
+fn solve_t_random_complex() {
+    for n in 0..=8 {
+        for &set_f in &[false, true] {
+            test_solve_all!(
+                [c32 => 1e-3, c64 => 1e-9],
+                a = random([n; 2].set_f(set_f)),
+                x = random(n),
+                b = a.t().dot(&x),
+                [solve_t, solve_t_into, solve_t_inplace],
+            );
+        }
+    }
+}
+
+#[test]
+fn solve_h_random_float() {
+    for n in 0..=8 {
+        for &set_f in &[false, true] {
+            test_solve_all!(
+                [f32 => 1e-3, f64 => 1e-9],
+                a = random([n; 2].set_f(set_f)),
+                x = random(n),
+                b = a.t().mapv(|x| x.conj()).dot(&x),
+                [solve_h, solve_h_into, solve_h_inplace],
+            );
+        }
+    }
+}
+
+#[test]
+fn solve_h_random_complex() {
+    for n in 0..=8 {
+        for &set_f in &[false, true] {
+            test_solve_all!(
+                [c32 => 1e-3, c64 => 1e-9],
+                a = random([n; 2].set_f(set_f)),
+                x = random(n),
+                b = a.t().mapv(|x| x.conj()).dot(&x),
+                [solve_h, solve_h_into, solve_h_inplace],
+            );
+        }
+    }
 }
 
 #[test]


### PR DESCRIPTION
This PR adds more tests for the `Solve` trait and fixes the implementation of `solve_h_*` for complex inputs with standard layout.