### PR TITLE
Relax requirement for DataMut on SVDCC

### DIFF
--- a/ndarray-linalg/src/svddc.rs
+++ b/ndarray-linalg/src/svddc.rs
@@ -38,7 +38,7 @@ pub trait SVDDCInplace {
 impl<A, S> SVDDC for ArrayBase<S, Ix2>
 where
     A: Scalar + Lapack,
-    S: DataMut<Elem = A>,
+    S: Data<Elem = A>,
 {
     type U = Array2<A>;
     type VT = Array2<A>;


### PR DESCRIPTION
The `SVDDCInto` trait should require `self` to be `DataMut`, but for the `SVDDC` trait we only need `self` to be `Data` since we do not own it.