### PR TITLE
bump lax intel-mkl-src

### DIFF
--- a/lax/Cargo.toml
+++ b/lax/Cargo.toml
@@ -35,7 +35,7 @@ num-traits = "0.2.14"
 lapack = "0.18.0"
 
 [dependencies.intel-mkl-src]
-version = "0.6.0"
+version = "0.7.0"
 default-features = false
 optional = true
 


### PR DESCRIPTION
following the fix of a long outstanding issue (https://github.com/rust-math/intel-mkl-src/pull/70) this PR bumps `intel-mkl-src` to latest