### PR TITLE
Use intel-mkl-system feature to calc coverage

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,6 +33,6 @@ jobs:
       - uses: actions/checkout@v2
       - name: Generate code coverage
         run: |
-          cargo tarpaulin --verbose --features=intel-mkl --out Xml --manifest-path=ndarray-linalg/Cargo.toml
+          cargo tarpaulin --features=intel-mkl-system --out Xml
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v1


### PR DESCRIPTION
~~Use new container~~ -> #323 

Coverage job on master fails with link error
https://github.com/rust-ndarray/ndarray-linalg/runs/8094527572?check_suite_focus=true

This occurs with `intel-mkl-static` feature. This PR tries to use `intel-mkl-system` feature instead.