### PR TITLE
Generate lax code from lapack-sys crate

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "lax-bindgen/lapack-sys"]
+	path = lax-bindgen/lapack-sys
+	url = git@github.com:blas-lapack-rs/lapack-sys.git

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,4 +2,5 @@
 members = [
   "ndarray-linalg",
   "lax",
+  "lax-bindgen",
 ]

--- a/lax-bindgen/Cargo.toml
+++ b/lax-bindgen/Cargo.toml
@@ -6,3 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1.0.62"
+proc-macro2 = "1.0.43"
+quote = "1.0.21"
+syn = { version = "1.0.99", features = ["full", "extra-traits"] }

--- a/lax-bindgen/Cargo.toml
+++ b/lax-bindgen/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "lax-bindgen"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/lax-bindgen/src/main.rs
+++ b/lax-bindgen/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/lax-bindgen/src/main.rs
+++ b/lax-bindgen/src/main.rs
@@ -1,3 +1,12 @@
-fn main() {
-    println!("Hello, world!");
+use anyhow::Result;
+use std::{fs, path::PathBuf};
+
+fn main() -> Result<()> {
+    let crate_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let lapack_sys = fs::read_to_string(crate_root.join("lapack-sys/src/lapack.rs"))?;
+
+    let file: syn::File = syn::parse_str(&lapack_sys)?;
+    dbg!(file);
+
+    Ok(())
 }


### PR DESCRIPTION
lapack-sys crate has been generated using rust-bindgen from `lapack.h` of LAPACKE project at https://github.com/blas-lapack-rs/lapack-sys/blob/master/bin/generate.sh

This PR try to generate idiomatic rust binding for as lax code as Rust (lapack-sys) to Rust (lax) code generation based on proc-macro utilities (syn, quote, proc-macro2).

This is a revival of https://github.com/blas-lapack-rs/lapack-sys/pull/12 