### PR TITLE
Use lapack-sys crate directly from lax crate

### DIFF
--- a/lax/Cargo.toml
+++ b/lax/Cargo.toml
@@ -32,7 +32,6 @@ intel-mkl-system = ["intel-mkl-src/mkl-dynamic-lp64-seq"]
 thiserror = "1.0.24"
 cauchy = "0.4.0"
 num-traits = "0.2.14"
-lapack = "0.18.0"
 lapack-sys = "0.14.0"
 
 [dependencies.intel-mkl-src]

--- a/lax/Cargo.toml
+++ b/lax/Cargo.toml
@@ -33,6 +33,7 @@ thiserror = "1.0.24"
 cauchy = "0.4.0"
 num-traits = "0.2.14"
 lapack = "0.18.0"
+lapack-sys = "0.14.0"
 
 [dependencies.intel-mkl-src]
 version = "0.7.0"

--- a/lax/src/cholesky.rs
+++ b/lax/src/cholesky.rs
@@ -29,7 +29,7 @@ macro_rules! impl_cholesky {
                 }
                 let mut info = 0;
                 unsafe {
-                    $trf(uplo as u8, n, a, n, &mut info);
+                    $trf(uplo.as_ptr(), &n, AsPtr::as_mut_ptr(a), &n, &mut info);
                 }
                 info.as_lapack_result()?;
                 if matches!(l, MatrixLayout::C { .. }) {
@@ -45,7 +45,7 @@ macro_rules! impl_cholesky {
                 }
                 let mut info = 0;
                 unsafe {
-                    $tri(uplo as u8, n, a, l.lda(), &mut info);
+                    $tri(uplo.as_ptr(), &n, AsPtr::as_mut_ptr(a), &l.lda(), &mut info);
                 }
                 info.as_lapack_result()?;
                 if matches!(l, MatrixLayout::C { .. }) {
@@ -70,7 +70,16 @@ macro_rules! impl_cholesky {
                     }
                 }
                 unsafe {
-                    $trs(uplo as u8, n, nrhs, a, l.lda(), b, n, &mut info);
+                    $trs(
+                        uplo.as_ptr(),
+                        &n,
+                        &nrhs,
+                        AsPtr::as_ptr(a),
+                        &l.lda(),
+                        AsPtr::as_mut_ptr(b),
+                        &n,
+                        &mut info,
+                    );
                 }
                 info.as_lapack_result()?;
                 if matches!(l, MatrixLayout::C { .. }) {
@@ -84,7 +93,27 @@ macro_rules! impl_cholesky {
     };
 } // end macro_rules
 
-impl_cholesky!(f64, lapack::dpotrf, lapack::dpotri, lapack::dpotrs);
-impl_cholesky!(f32, lapack::spotrf, lapack::spotri, lapack::spotrs);
-impl_cholesky!(c64, lapack::zpotrf, lapack::zpotri, lapack::zpotrs);
-impl_cholesky!(c32, lapack::cpotrf, lapack::cpotri, lapack::cpotrs);
+impl_cholesky!(
+    f64,
+    lapack_sys::dpotrf_,
+    lapack_sys::dpotri_,
+    lapack_sys::dpotrs_
+);
+impl_cholesky!(
+    f32,
+    lapack_sys::spotrf_,
+    lapack_sys::spotri_,
+    lapack_sys::spotrs_
+);
+impl_cholesky!(
+    c64,
+    lapack_sys::zpotrf_,
+    lapack_sys::zpotri_,
+    lapack_sys::zpotrs_
+);
+impl_cholesky!(
+    c32,
+    lapack_sys::cpotrf_,
+    lapack_sys::cpotri_,
+    lapack_sys::cpotrs_
+);

--- a/lax/src/eig.rs
+++ b/lax/src/eig.rs
@@ -35,21 +35,21 @@ macro_rules! impl_eig_complex {
                 // eigenvalues are the eigenvalues computed with `A`.
                 let (jobvl, jobvr) = if calc_v {
                     match l {
-                        MatrixLayout::C { .. } => (b'V', b'N'),
-                        MatrixLayout::F { .. } => (b'N', b'V'),
+                        MatrixLayout::C { .. } => (EigenVectorFlag::Calc, EigenVectorFlag::Not),
+                        MatrixLayout::F { .. } => (EigenVectorFlag::Not, EigenVectorFlag::Calc),
                     }
                 } else {
-                    (b'N', b'N')
+                    (EigenVectorFlag::Not, EigenVectorFlag::Not)
                 };
                 let mut eigs = unsafe { vec_uninit(n as usize) };
                 let mut rwork = unsafe { vec_uninit(2 * n as usize) };
 
-                let mut vl = if jobvl == b'V' {
+                let mut vl = if jobvl == EigenVectorFlag::Calc {
                     Some(unsafe { vec_uninit((n * n) as usize) })
                 } else {
                     None
                 };
-                let mut vr = if jobvr == b'V' {
+                let mut vr = if jobvr == EigenVectorFlag::Calc {
                     Some(unsafe { vec_uninit((n * n) as usize) })
                 } else {
                     None
@@ -60,8 +60,8 @@ macro_rules! impl_eig_complex {
                 let mut work_size = [Self::zero()];
                 unsafe {
                     $ev(
-                        jobvl,
-                        jobvr,
+                        jobvl as u8,
+                        jobvr as u8,
                         n,
                         &mut a,
                         n,
@@ -83,8 +83,8 @@ macro_rules! impl_eig_complex {
                 let mut work = unsafe { vec_uninit(lwork) };
                 unsafe {
                     $ev(
-                        jobvl,
-                        jobvr,
+                        jobvl as u8,
+                        jobvr as u8,
                         n,
                         &mut a,
                         n,
@@ -102,7 +102,7 @@ macro_rules! impl_eig_complex {
                 info.as_lapack_result()?;
 
                 // Hermite conjugate
-                if jobvl == b'V' {
+                if jobvl == EigenVectorFlag::Calc {
                     for c in vl.as_mut().unwrap().iter_mut() {
                         c.im = -c.im
                     }
@@ -144,21 +144,21 @@ macro_rules! impl_eig_real {
                 // `sgeev`/`dgeev`.
                 let (jobvl, jobvr) = if calc_v {
                     match l {
-                        MatrixLayout::C { .. } => (b'V', b'N'),
-                        MatrixLayout::F { .. } => (b'N', b'V'),
+                        MatrixLayout::C { .. } => (EigenVectorFlag::Calc, EigenVectorFlag::Not),
+                        MatrixLayout::F { .. } => (EigenVectorFlag::Not, EigenVectorFlag::Calc),
                     }
                 } else {
-                    (b'N', b'N')
+                    (EigenVectorFlag::Not, EigenVectorFlag::Not)
                 };
                 let mut eig_re = unsafe { vec_uninit(n as usize) };
                 let mut eig_im = unsafe { vec_uninit(n as usize) };
 
-                let mut vl = if jobvl == b'V' {
+                let mut vl = if jobvl == EigenVectorFlag::Calc {
                     Some(unsafe { vec_uninit((n * n) as usize) })
                 } else {
                     None
                 };
-                let mut vr = if jobvr == b'V' {
+                let mut vr = if jobvr == EigenVectorFlag::Calc {
                     Some(unsafe { vec_uninit((n * n) as usize) })
                 } else {
                     None
@@ -169,8 +169,8 @@ macro_rules! impl_eig_real {
                 let mut work_size = [0.0];
                 unsafe {
                     $ev(
-                        jobvl,
-                        jobvr,
+                        jobvl as u8,
+                        jobvr as u8,
                         n,
                         &mut a,
                         n,
@@ -192,8 +192,8 @@ macro_rules! impl_eig_real {
                 let mut work = unsafe { vec_uninit(lwork) };
                 unsafe {
                     $ev(
-                        jobvl,
-                        jobvr,
+                        jobvl as u8,
+                        jobvr as u8,
                         n,
                         &mut a,
                         n,
@@ -254,7 +254,7 @@ macro_rules! impl_eig_real {
                         for row in 0..n {
                             let re = v[row + col * n];
                             let mut im = v[row + (col + 1) * n];
-                            if jobvl == b'V' {
+                            if jobvl == EigenVectorFlag::Calc {
                                 im = -im;
                             }
                             eigvecs[row + col * n] = Self::complex(re, im);

--- a/lax/src/eig.rs
+++ b/lax/src/eig.rs
@@ -44,16 +44,8 @@ macro_rules! impl_eig_complex {
                 let mut eigs = unsafe { vec_uninit(n as usize) };
                 let mut rwork = unsafe { vec_uninit(2 * n as usize) };
 
-                let mut vl = if jobvl == EigenVectorFlag::Calc {
-                    Some(unsafe { vec_uninit((n * n) as usize) })
-                } else {
-                    None
-                };
-                let mut vr = if jobvr == EigenVectorFlag::Calc {
-                    Some(unsafe { vec_uninit((n * n) as usize) })
-                } else {
-                    None
-                };
+                let mut vl = jobvl.then(|| unsafe { vec_uninit((n * n) as usize) });
+                let mut vr = jobvr.then(|| unsafe { vec_uninit((n * n) as usize) });
 
                 // calc work size
                 let mut info = 0;
@@ -102,7 +94,7 @@ macro_rules! impl_eig_complex {
                 info.as_lapack_result()?;
 
                 // Hermite conjugate
-                if jobvl == EigenVectorFlag::Calc {
+                if jobvl.is_calc() {
                     for c in vl.as_mut().unwrap().iter_mut() {
                         c.im = -c.im
                     }
@@ -153,16 +145,10 @@ macro_rules! impl_eig_real {
                 let mut eig_re: Vec<Self> = unsafe { vec_uninit(n as usize) };
                 let mut eig_im: Vec<Self> = unsafe { vec_uninit(n as usize) };
 
-                let mut vl: Option<Vec<Self>> = if jobvl == EigenVectorFlag::Calc {
-                    Some(unsafe { vec_uninit((n * n) as usize) })
-                } else {
-                    None
-                };
-                let mut vr: Option<Vec<Self>> = if jobvr == EigenVectorFlag::Calc {
-                    Some(unsafe { vec_uninit((n * n) as usize) })
-                } else {
-                    None
-                };
+                let mut vl: Option<Vec<Self>> =
+                    jobvl.then(|| unsafe { vec_uninit((n * n) as usize) });
+                let mut vr: Option<Vec<Self>> =
+                    jobvr.then(|| unsafe { vec_uninit((n * n) as usize) });
 
                 // calc work size
                 let mut info = 0;
@@ -255,7 +241,7 @@ macro_rules! impl_eig_real {
                         for row in 0..n {
                             let re = v[row + col * n];
                             let mut im = v[row + (col + 1) * n];
-                            if jobvl == EigenVectorFlag::Calc {
+                            if jobvl.is_calc() {
                                 im = -im;
                             }
                             eigvecs[row + col * n] = Self::complex(re, im);

--- a/lax/src/eigh.rs
+++ b/lax/src/eigh.rs
@@ -41,7 +41,7 @@ macro_rules! impl_eigh {
             ) -> Result<Vec<Self::Real>> {
                 assert_eq!(layout.len(), layout.lda());
                 let n = layout.len();
-                let jobz = if calc_v { b'V' } else { b'N' };
+                let jobz = if calc_v { EigenVectorFlag::Calc } else { EigenVectorFlag::Not };
                 let mut eigs = unsafe { vec_uninit(n as usize) };
 
                 $(
@@ -53,7 +53,7 @@ macro_rules! impl_eigh {
                 let mut work_size = [Self::zero()];
                 unsafe {
                     $ev(
-                        jobz,
+                        jobz as u8,
                         uplo as u8,
                         n,
                         &mut a,
@@ -72,7 +72,7 @@ macro_rules! impl_eigh {
                 let mut work = unsafe { vec_uninit(lwork) };
                 unsafe {
                     $ev(
-                        jobz,
+                        jobz as u8,
                         uplo as u8,
                         n,
                         &mut a,
@@ -97,7 +97,7 @@ macro_rules! impl_eigh {
             ) -> Result<Vec<Self::Real>> {
                 assert_eq!(layout.len(), layout.lda());
                 let n = layout.len();
-                let jobz = if calc_v { b'V' } else { b'N' };
+                let jobz = if calc_v { EigenVectorFlag::Calc } else { EigenVectorFlag::Not };
                 let mut eigs = unsafe { vec_uninit(n as usize) };
 
                 $(
@@ -110,7 +110,7 @@ macro_rules! impl_eigh {
                 unsafe {
                     $evg(
                         &[1],
-                        jobz,
+                        jobz as u8,
                         uplo as u8,
                         n,
                         &mut a,
@@ -132,7 +132,7 @@ macro_rules! impl_eigh {
                 unsafe {
                     $evg(
                         &[1],
-                        jobz,
+                        jobz as u8,
                         uplo as u8,
                         n,
                         &mut a,

--- a/lax/src/eigh.rs
+++ b/lax/src/eigh.rs
@@ -37,7 +37,7 @@ macro_rules! impl_eigh {
                 calc_v: bool,
                 layout: MatrixLayout,
                 uplo: UPLO,
-                mut a: &mut [Self],
+                a: &mut [Self],
             ) -> Result<Vec<Self::Real>> {
                 assert_eq!(layout.len(), layout.lda());
                 let n = layout.len();
@@ -45,7 +45,7 @@ macro_rules! impl_eigh {
                 let mut eigs = unsafe { vec_uninit(n as usize) };
 
                 $(
-                let mut $rwork_ident = unsafe { vec_uninit(3 * n as usize - 2 as usize) };
+                let mut $rwork_ident: Vec<Self::Real> = unsafe { vec_uninit(3 * n as usize - 2 as usize) };
                 )*
 
                 // calc work size
@@ -53,15 +53,15 @@ macro_rules! impl_eigh {
                 let mut work_size = [Self::zero()];
                 unsafe {
                     $ev(
-                        jobz as u8,
-                        uplo as u8,
-                        n,
-                        &mut a,
-                        n,
-                        &mut eigs,
-                        &mut work_size,
-                        -1,
-                        $(&mut $rwork_ident,)*
+                        jobz.as_ptr() ,
+                        uplo.as_ptr(),
+                        &n,
+                        AsPtr::as_mut_ptr(a),
+                        &n,
+                        AsPtr::as_mut_ptr(&mut eigs),
+                        AsPtr::as_mut_ptr(&mut work_size),
+                        &(-1),
+                        $(AsPtr::as_mut_ptr(&mut $rwork_ident),)*
                         &mut info,
                     );
                 }
@@ -69,18 +69,19 @@ macro_rules! impl_eigh {
 
                 // actual ev
                 let lwork = work_size[0].to_usize().unwrap();
-                let mut work = unsafe { vec_uninit(lwork) };
+                let mut work: Vec<Self> = unsafe { vec_uninit(lwork) };
+                let lwork = lwork as i32;
                 unsafe {
                     $ev(
-                        jobz as u8,
-                        uplo as u8,
-                        n,
-                        &mut a,
-                        n,
-                        &mut eigs,
-                        &mut work,
-                        lwork as i32,
-                        $(&mut $rwork_ident,)*
+                        jobz.as_ptr(),
+                        uplo.as_ptr(),
+                        &n,
+                        AsPtr::as_mut_ptr(a),
+                        &n,
+                        AsPtr::as_mut_ptr(&mut eigs),
+                        AsPtr::as_mut_ptr(&mut work),
+                        &lwork,
+                        $(AsPtr::as_mut_ptr(&mut $rwork_ident),)*
                         &mut info,
                     );
                 }
@@ -92,8 +93,8 @@ macro_rules! impl_eigh {
                 calc_v: bool,
                 layout: MatrixLayout,
                 uplo: UPLO,
-                mut a: &mut [Self],
-                mut b: &mut [Self],
+                a: &mut [Self],
+                b: &mut [Self],
             ) -> Result<Vec<Self::Real>> {
                 assert_eq!(layout.len(), layout.lda());
                 let n = layout.len();
@@ -101,7 +102,7 @@ macro_rules! impl_eigh {
                 let mut eigs = unsafe { vec_uninit(n as usize) };
 
                 $(
-                let mut $rwork_ident = unsafe { vec_uninit(3 * n as usize - 2) };
+                let mut $rwork_ident: Vec<Self::Real> = unsafe { vec_uninit(3 * n as usize - 2) };
                 )*
 
                 // calc work size
@@ -109,18 +110,18 @@ macro_rules! impl_eigh {
                 let mut work_size = [Self::zero()];
                 unsafe {
                     $evg(
-                        &[1],
-                        jobz as u8,
-                        uplo as u8,
-                        n,
-                        &mut a,
-                        n,
-                        &mut b,
-                        n,
-                        &mut eigs,
-                        &mut work_size,
-                        -1,
-                        $(&mut $rwork_ident,)*
+                        &1, // ITYPE A*x = (lambda)*B*x
+                        jobz.as_ptr(),
+                        uplo.as_ptr(),
+                        &n,
+                        AsPtr::as_mut_ptr(a),
+                        &n,
+                        AsPtr::as_mut_ptr(b),
+                        &n,
+                        AsPtr::as_mut_ptr(&mut eigs),
+                        AsPtr::as_mut_ptr(&mut work_size),
+                        &(-1),
+                        $(AsPtr::as_mut_ptr(&mut $rwork_ident),)*
                         &mut info,
                     );
                 }
@@ -128,21 +129,22 @@ macro_rules! impl_eigh {
 
                 // actual evg
                 let lwork = work_size[0].to_usize().unwrap();
-                let mut work = unsafe { vec_uninit(lwork) };
+                let mut work: Vec<Self> = unsafe { vec_uninit(lwork) };
+                let lwork = lwork as i32;
                 unsafe {
                     $evg(
-                        &[1],
-                        jobz as u8,
-                        uplo as u8,
-                        n,
-                        &mut a,
-                        n,
-                        &mut b,
-                        n,
-                        &mut eigs,
-                        &mut work,
-                        lwork as i32,
-                        $(&mut $rwork_ident,)*
+                        &1, // ITYPE A*x = (lambda)*B*x
+                        jobz.as_ptr(),
+                        uplo.as_ptr(),
+                        &n,
+                        AsPtr::as_mut_ptr(a),
+                        &n,
+                        AsPtr::as_mut_ptr(b),
+                        &n,
+                        AsPtr::as_mut_ptr(&mut eigs),
+                        AsPtr::as_mut_ptr(&mut work),
+                        &lwork,
+                        $(AsPtr::as_mut_ptr(&mut $rwork_ident),)*
                         &mut info,
                     );
                 }
@@ -153,7 +155,7 @@ macro_rules! impl_eigh {
     };
 } // impl_eigh!
 
-impl_eigh!(@real, f64, lapack::dsyev, lapack::dsygv);
-impl_eigh!(@real, f32, lapack::ssyev, lapack::ssygv);
-impl_eigh!(@complex, c64, lapack::zheev, lapack::zhegv);
-impl_eigh!(@complex, c32, lapack::cheev, lapack::chegv);
+impl_eigh!(@real, f64, lapack_sys::dsyev_, lapack_sys::dsygv_);
+impl_eigh!(@real, f32, lapack_sys::ssyev_, lapack_sys::ssygv_);
+impl_eigh!(@complex, c64, lapack_sys::zheev_, lapack_sys::zhegv_);
+impl_eigh!(@complex, c32, lapack_sys::cheev_, lapack_sys::chegv_);

--- a/lax/src/lib.rs
+++ b/lax/src/lib.rs
@@ -220,6 +220,21 @@ pub enum EigenVectorFlag {
 }
 
 impl EigenVectorFlag {
+    pub fn is_calc(&self) -> bool {
+        match self {
+            EigenVectorFlag::Calc => true,
+            EigenVectorFlag::Not => false,
+        }
+    }
+
+    pub fn then<T, F: FnOnce() -> T>(&self, f: F) -> Option<T> {
+        if self.is_calc() {
+            Some(f())
+        } else {
+            None
+        }
+    }
+
     /// To use Fortran LAPACK API in lapack-sys crate
     pub fn as_ptr(&self) -> *const i8 {
         self as *const EigenVectorFlag as *const i8

--- a/lax/src/lib.rs
+++ b/lax/src/lib.rs
@@ -211,6 +211,21 @@ impl NormType {
     }
 }
 
+/// Flag for calculating eigenvectors or not
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum EigenVectorFlag {
+    Calc = b'V',
+    Not = b'N',
+}
+
+impl EigenVectorFlag {
+    /// To use Fortran LAPACK API in lapack-sys crate
+    pub fn as_ptr(&self) -> *const i8 {
+        self as *const EigenVectorFlag as *const i8
+    }
+}
+
 /// Create a vector without initialization
 ///
 /// Safety

--- a/lax/src/lib.rs
+++ b/lax/src/lib.rs
@@ -141,6 +141,11 @@ impl UPLO {
             UPLO::Lower => UPLO::Upper,
         }
     }
+
+    /// To use Fortran LAPACK API in lapack-sys crate
+    pub fn as_ptr(&self) -> *const i8 {
+        self as *const UPLO as *const i8
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -149,6 +154,13 @@ pub enum Transpose {
     No = b'N',
     Transpose = b'T',
     Hermite = b'C',
+}
+
+impl Transpose {
+    /// To use Fortran LAPACK API in lapack-sys crate
+    pub fn as_ptr(&self) -> *const i8 {
+        self as *const Transpose as *const i8
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -166,6 +178,11 @@ impl NormType {
             NormType::Infinity => NormType::One,
             NormType::Frobenius => NormType::Frobenius,
         }
+    }
+
+    /// To use Fortran LAPACK API in lapack-sys crate
+    pub fn as_ptr(&self) -> *const i8 {
+        self as *const NormType as *const i8
     }
 }
 

--- a/lax/src/lib.rs
+++ b/lax/src/lib.rs
@@ -126,6 +126,31 @@ impl Lapack for f64 {}
 impl Lapack for c32 {}
 impl Lapack for c64 {}
 
+/// Helper for getting pointer of slice
+pub(crate) trait AsPtr: Sized {
+    type Elem;
+    fn as_ptr(vec: &[Self]) -> *const Self::Elem;
+    fn as_mut_ptr(vec: &mut [Self]) -> *mut Self::Elem;
+}
+
+macro_rules! impl_as_ptr {
+    ($target:ty, $elem:ty) => {
+        impl AsPtr for $target {
+            type Elem = $elem;
+            fn as_ptr(vec: &[Self]) -> *const Self::Elem {
+                vec.as_ptr() as *const _
+            }
+            fn as_mut_ptr(vec: &mut [Self]) -> *mut Self::Elem {
+                vec.as_mut_ptr() as *mut _
+            }
+        }
+    };
+}
+impl_as_ptr!(f32, f32);
+impl_as_ptr!(f64, f64);
+impl_as_ptr!(c32, lapack_sys::__BindgenComplex<f32>);
+impl_as_ptr!(c64, lapack_sys::__BindgenComplex<f64>);
+
 /// Upper/Lower specification for seveal usages
 #[derive(Debug, Clone, Copy)]
 #[repr(u8)]

--- a/lax/src/rcond.rs
+++ b/lax/src/rcond.rs
@@ -17,22 +17,22 @@ macro_rules! impl_rcond_real {
                 let mut rcond = Self::Real::zero();
                 let mut info = 0;
 
-                let mut work = unsafe { vec_uninit(4 * n as usize) };
+                let mut work: Vec<Self> = unsafe { vec_uninit(4 * n as usize) };
                 let mut iwork = unsafe { vec_uninit(n as usize) };
                 let norm_type = match l {
                     MatrixLayout::C { .. } => NormType::Infinity,
                     MatrixLayout::F { .. } => NormType::One,
-                } as u8;
+                };
                 unsafe {
                     $gecon(
-                        norm_type,
-                        n,
-                        a,
-                        l.lda(),
-                        anorm,
+                        norm_type.as_ptr(),
+                        &n,
+                        AsPtr::as_ptr(a),
+                        &l.lda(),
+                        &anorm,
                         &mut rcond,
-                        &mut work,
-                        &mut iwork,
+                        AsPtr::as_mut_ptr(&mut work),
+                        iwork.as_mut_ptr(),
                         &mut info,
                     )
                 };
@@ -44,8 +44,8 @@ macro_rules! impl_rcond_real {
     };
 }
 
-impl_rcond_real!(f32, lapack::sgecon);
-impl_rcond_real!(f64, lapack::dgecon);
+impl_rcond_real!(f32, lapack_sys::sgecon_);
+impl_rcond_real!(f64, lapack_sys::dgecon_);
 
 macro_rules! impl_rcond_complex {
     ($scalar:ty, $gecon:path) => {

--- a/lax/src/rcond.rs
+++ b/lax/src/rcond.rs
@@ -54,22 +54,22 @@ macro_rules! impl_rcond_complex {
                 let (n, _) = l.size();
                 let mut rcond = Self::Real::zero();
                 let mut info = 0;
-                let mut work = unsafe { vec_uninit(2 * n as usize) };
-                let mut rwork = unsafe { vec_uninit(2 * n as usize) };
+                let mut work: Vec<Self> = unsafe { vec_uninit(2 * n as usize) };
+                let mut rwork: Vec<Self::Real> = unsafe { vec_uninit(2 * n as usize) };
                 let norm_type = match l {
                     MatrixLayout::C { .. } => NormType::Infinity,
                     MatrixLayout::F { .. } => NormType::One,
-                } as u8;
+                };
                 unsafe {
                     $gecon(
-                        norm_type,
-                        n,
-                        a,
-                        l.lda(),
-                        anorm,
+                        norm_type.as_ptr(),
+                        &n,
+                        AsPtr::as_ptr(a),
+                        &l.lda(),
+                        &anorm,
                         &mut rcond,
-                        &mut work,
-                        &mut rwork,
+                        AsPtr::as_mut_ptr(&mut work),
+                        AsPtr::as_mut_ptr(&mut rwork),
                         &mut info,
                     )
                 };
@@ -81,5 +81,5 @@ macro_rules! impl_rcond_complex {
     };
 }
 
-impl_rcond_complex!(c32, lapack::cgecon);
-impl_rcond_complex!(c64, lapack::zgecon);
+impl_rcond_complex!(c32, lapack_sys::cgecon_);
+impl_rcond_complex!(c64, lapack_sys::zgecon_);

--- a/lax/src/triangular.rs
+++ b/lax/src/triangular.rs
@@ -10,6 +10,12 @@ pub enum Diag {
     NonUnit = b'N',
 }
 
+impl Diag {
+    fn as_ptr(&self) -> *const i8 {
+        self as *const Diag as *const i8
+    }
+}
+
 /// Wraps `*trtri` and `*trtrs`
 pub trait Triangular_: Scalar {
     fn solve_triangular(
@@ -60,15 +66,15 @@ macro_rules! impl_triangular {
                 let mut info = 0;
                 unsafe {
                     $trtrs(
-                        uplo as u8,
-                        Transpose::No as u8,
-                        diag as u8,
-                        m,
-                        nrhs,
-                        a_t.as_ref().map(|v| v.as_slice()).unwrap_or(a),
-                        a_layout.lda(),
-                        b_t.as_mut().map(|v| v.as_mut_slice()).unwrap_or(b),
-                        b_layout.lda(),
+                        uplo.as_ptr(),
+                        Transpose::No.as_ptr(),
+                        diag.as_ptr(),
+                        &m,
+                        &nrhs,
+                        AsPtr::as_ptr(a_t.as_ref().map(|v| v.as_slice()).unwrap_or(a)),
+                        &a_layout.lda(),
+                        AsPtr::as_mut_ptr(b_t.as_mut().map(|v| v.as_mut_slice()).unwrap_or(b)),
+                        &b_layout.lda(),
                         &mut info,
                     );
                 }
@@ -84,7 +90,7 @@ macro_rules! impl_triangular {
     };
 } // impl_triangular!
 
-impl_triangular!(f64, lapack::dtrtri, lapack::dtrtrs);
-impl_triangular!(f32, lapack::strtri, lapack::strtrs);
-impl_triangular!(c64, lapack::ztrtri, lapack::ztrtrs);
-impl_triangular!(c32, lapack::ctrtri, lapack::ctrtrs);
+impl_triangular!(f64, lapack_sys::dtrtri_, lapack_sys::dtrtrs_);
+impl_triangular!(f32, lapack_sys::strtri_, lapack_sys::strtrs_);
+impl_triangular!(c64, lapack_sys::ztrtri_, lapack_sys::ztrtrs_);
+impl_triangular!(c32, lapack_sys::ctrtri_, lapack_sys::ctrtrs_);


### PR DESCRIPTION
First step of #327.

The problem of `lapack` crate is it requires slice `&[T]` which must be initialized while the pointer-based API in `lapack-sys` does not.