### PR TITLE
Strict memory management for `lax::Eig_`

### DIFF
--- a/lax/src/alloc.rs
+++ b/lax/src/alloc.rs
@@ -33,17 +33,33 @@ impl_as_ptr!(MaybeUninit<c32>, lapack_sys::__BindgenComplex<f32>);
 impl_as_ptr!(MaybeUninit<c64>, lapack_sys::__BindgenComplex<f64>);
 
 pub(crate) trait VecAssumeInit {
-    type Target;
-    unsafe fn assume_init(self) -> Self::Target;
+    type Elem;
+    unsafe fn assume_init(self) -> Vec<Self::Elem>;
+
+    /// An replacement of unstable API
+    /// https://doc.rust-lang.org/std/mem/union.MaybeUninit.html#method.slice_assume_init_ref
+    unsafe fn slice_assume_init_ref(&self) -> &[Self::Elem];
+
+    /// An replacement of unstable API
+    /// https://doc.rust-lang.org/std/mem/union.MaybeUninit.html#method.slice_assume_init_mut
+    unsafe fn slice_assume_init_mut(&mut self) -> &mut [Self::Elem];
 }
 
 impl<T> VecAssumeInit for Vec<MaybeUninit<T>> {
-    type Target = Vec<T>;
-    unsafe fn assume_init(self) -> Self::Target {
+    type Elem = T;
+    unsafe fn assume_init(self) -> Vec<T> {
         // FIXME use Vec::into_raw_parts instead after stablized
         // https://doc.rust-lang.org/std/vec/struct.Vec.html#method.into_raw_parts
         let mut me = std::mem::ManuallyDrop::new(self);
         Vec::from_raw_parts(me.as_mut_ptr() as *mut T, me.len(), me.capacity())
+    }
+
+    unsafe fn slice_assume_init_ref(&self) -> &[T] {
+        std::slice::from_raw_parts(self.as_ptr() as *const T, self.len())
+    }
+
+    unsafe fn slice_assume_init_mut(&mut self) -> &mut [T] {
+        std::slice::from_raw_parts_mut(self.as_mut_ptr() as *mut T, self.len())
     }
 }
 

--- a/lax/src/eig.rs
+++ b/lax/src/eig.rs
@@ -32,6 +32,33 @@ pub trait Eig_: Scalar {
     ) -> Result<(Vec<Self::Complex>, Vec<Self::Complex>)>;
 }
 
+/// Working memory for [Eig_]
+#[derive(Debug, Clone)]
+pub struct EigWork<T: Scalar> {
+    pub n: i32,
+    pub jobvr: JobEv,
+    pub jobvl: JobEv,
+
+    /// Eigenvalues used in complex routines
+    pub eigs: Vec<MaybeUninit<T::Complex>>,
+    /// Real part of eigenvalues used in real routines
+    pub eigs_re: Option<Vec<MaybeUninit<T::Real>>>,
+    /// Imaginary part of eigenvalues used in real routines
+    pub eigs_im: Option<Vec<MaybeUninit<T::Real>>>,
+
+    /// Left eigenvectors
+    pub vc_l: Option<Vec<MaybeUninit<T::Complex>>>,
+    pub vr_l: Option<Vec<MaybeUninit<T::Real>>>,
+    /// Right eigenvectors
+    pub vc_r: Option<Vec<MaybeUninit<T::Complex>>>,
+    pub vr_r: Option<Vec<MaybeUninit<T::Real>>>,
+
+    /// Working memory
+    pub work: Vec<MaybeUninit<T>>,
+    /// Working memory with `T::Real`
+    pub rwork: Option<Vec<MaybeUninit<T::Real>>>,
+}
+
 macro_rules! impl_eig_complex {
     ($scalar:ty, $ev:path) => {
         impl Eig_ for $scalar {

--- a/lax/src/eig.rs
+++ b/lax/src/eig.rs
@@ -227,6 +227,179 @@ impl EigWorkImpl for EigWork<c64> {
     }
 }
 
+impl EigWorkImpl for EigWork<f64> {
+    type Elem = f64;
+
+    fn new(calc_v: bool, l: MatrixLayout) -> Result<Self> {
+        let (n, _) = l.size();
+        let (jobvl, jobvr) = if calc_v {
+            match l {
+                MatrixLayout::C { .. } => (JobEv::All, JobEv::None),
+                MatrixLayout::F { .. } => (JobEv::None, JobEv::All),
+            }
+        } else {
+            (JobEv::None, JobEv::None)
+        };
+        let mut eigs_re: Vec<MaybeUninit<f64>> = vec_uninit(n as usize);
+        let mut eigs_im: Vec<MaybeUninit<f64>> = vec_uninit(n as usize);
+
+        let mut vr_l: Option<Vec<MaybeUninit<f64>>> = jobvl.then(|| vec_uninit((n * n) as usize));
+        let mut vr_r: Option<Vec<MaybeUninit<f64>>> = jobvr.then(|| vec_uninit((n * n) as usize));
+        let vc_l: Option<Vec<MaybeUninit<c64>>> = jobvl.then(|| vec_uninit((n * n) as usize));
+        let vc_r: Option<Vec<MaybeUninit<c64>>> = jobvr.then(|| vec_uninit((n * n) as usize));
+
+        // calc work size
+        let mut info = 0;
+        let mut work_size: [f64; 1] = [0.0];
+        unsafe {
+            lapack_sys::dgeev_(
+                jobvl.as_ptr(),
+                jobvr.as_ptr(),
+                &n,
+                std::ptr::null_mut(),
+                &n,
+                AsPtr::as_mut_ptr(&mut eigs_re),
+                AsPtr::as_mut_ptr(&mut eigs_im),
+                AsPtr::as_mut_ptr(vr_l.as_deref_mut().unwrap_or(&mut [])),
+                &n,
+                AsPtr::as_mut_ptr(vr_r.as_deref_mut().unwrap_or(&mut [])),
+                &n,
+                AsPtr::as_mut_ptr(&mut work_size),
+                &(-1),
+                &mut info,
+            )
+        };
+        info.as_lapack_result()?;
+
+        // actual ev
+        let lwork = work_size[0].to_usize().unwrap();
+        let work: Vec<MaybeUninit<f64>> = vec_uninit(lwork);
+
+        Ok(Self {
+            n,
+            jobvr,
+            jobvl,
+            eigs: vec_uninit(n as usize),
+            eigs_re: Some(eigs_re),
+            eigs_im: Some(eigs_im),
+            rwork: None,
+            vr_l,
+            vr_r,
+            vc_l,
+            vc_r,
+            work,
+        })
+    }
+
+    fn calc<'work>(&'work mut self, a: &mut [f64]) -> Result<EigRef<'work, f64>> {
+        let lwork = self.work.len().to_i32().unwrap();
+        let mut info = 0;
+        unsafe {
+            lapack_sys::dgeev_(
+                self.jobvl.as_ptr(),
+                self.jobvr.as_ptr(),
+                &self.n,
+                AsPtr::as_mut_ptr(a),
+                &self.n,
+                AsPtr::as_mut_ptr(self.eigs_re.as_mut().unwrap()),
+                AsPtr::as_mut_ptr(self.eigs_im.as_mut().unwrap()),
+                AsPtr::as_mut_ptr(self.vr_l.as_deref_mut().unwrap_or(&mut [])),
+                &self.n,
+                AsPtr::as_mut_ptr(self.vr_r.as_deref_mut().unwrap_or(&mut [])),
+                &self.n,
+                AsPtr::as_mut_ptr(&mut self.work),
+                &lwork,
+                &mut info,
+            )
+        };
+        info.as_lapack_result()?;
+
+        let eigs_re: &[f64] = self
+            .eigs_re
+            .as_ref()
+            .map(|e| unsafe { e.slice_assume_init_ref() })
+            .unwrap();
+        let eigs_im: &[f64] = self
+            .eigs_im
+            .as_ref()
+            .map(|e| unsafe { e.slice_assume_init_ref() })
+            .unwrap();
+        reconstruct_eigs(eigs_re, eigs_im, &mut self.eigs);
+
+        if let Some(v) = self.vr_l.as_ref() {
+            let v = unsafe { v.slice_assume_init_ref() };
+            reconstruct_eigenvectors(false, eigs_im, v, self.vc_l.as_mut().unwrap());
+        }
+        if let Some(v) = self.vr_r.as_ref() {
+            let v = unsafe { v.slice_assume_init_ref() };
+            reconstruct_eigenvectors(false, eigs_im, v, self.vc_l.as_mut().unwrap());
+        }
+
+        Ok(EigRef {
+            eigs: unsafe { self.eigs.slice_assume_init_ref() },
+            vl: self
+                .vc_l
+                .as_ref()
+                .map(|v| unsafe { v.slice_assume_init_ref() }),
+            vr: self
+                .vc_r
+                .as_ref()
+                .map(|v| unsafe { v.slice_assume_init_ref() }),
+        })
+    }
+
+    fn eval(mut self, a: &mut [f64]) -> Result<Eig<f64>> {
+        let lwork = self.work.len().to_i32().unwrap();
+        let mut info = 0;
+        unsafe {
+            lapack_sys::dgeev_(
+                self.jobvl.as_ptr(),
+                self.jobvr.as_ptr(),
+                &self.n,
+                AsPtr::as_mut_ptr(a),
+                &self.n,
+                AsPtr::as_mut_ptr(self.eigs_re.as_mut().unwrap()),
+                AsPtr::as_mut_ptr(self.eigs_im.as_mut().unwrap()),
+                AsPtr::as_mut_ptr(self.vr_l.as_deref_mut().unwrap_or(&mut [])),
+                &self.n,
+                AsPtr::as_mut_ptr(self.vr_r.as_deref_mut().unwrap_or(&mut [])),
+                &self.n,
+                AsPtr::as_mut_ptr(&mut self.work),
+                &lwork,
+                &mut info,
+            )
+        };
+        info.as_lapack_result()?;
+
+        let eigs_re: &[f64] = self
+            .eigs_re
+            .as_ref()
+            .map(|e| unsafe { e.slice_assume_init_ref() })
+            .unwrap();
+        let eigs_im: &[f64] = self
+            .eigs_im
+            .as_ref()
+            .map(|e| unsafe { e.slice_assume_init_ref() })
+            .unwrap();
+        reconstruct_eigs(eigs_re, eigs_im, &mut self.eigs);
+
+        if let Some(v) = self.vr_l.as_ref() {
+            let v = unsafe { v.slice_assume_init_ref() };
+            reconstruct_eigenvectors(false, eigs_im, v, self.vc_l.as_mut().unwrap());
+        }
+        if let Some(v) = self.vr_r.as_ref() {
+            let v = unsafe { v.slice_assume_init_ref() };
+            reconstruct_eigenvectors(false, eigs_im, v, self.vc_l.as_mut().unwrap());
+        }
+
+        Ok(Eig {
+            eigs: unsafe { self.eigs.assume_init() },
+            vl: self.vc_l.map(|v| unsafe { v.assume_init() }),
+            vr: self.vc_r.map(|v| unsafe { v.assume_init() }),
+        })
+    }
+}
+
 macro_rules! impl_eig_complex {
     ($scalar:ty, $ev:path) => {
         impl Eig_ for $scalar {
@@ -429,55 +602,18 @@ macro_rules! impl_eig_real {
                     .map(|(&re, &im)| Self::complex(re, im))
                     .collect();
 
-                if !calc_v {
-                    return Ok((eigs, Vec::new()));
+                if calc_v {
+                    let mut eigvecs = vec_uninit((n * n) as usize);
+                    reconstruct_eigenvectors(
+                        jobvl.is_calc(),
+                        &eig_im,
+                        &vr.or(vl).unwrap(),
+                        &mut eigvecs,
+                    );
+                    Ok((eigs, unsafe { eigvecs.assume_init() }))
+                } else {
+                    Ok((eigs, Vec::new()))
                 }
-
-                // Reconstruct eigenvectors into complex-array
-                // --------------------------------------------
-                //
-                // From LAPACK API https://software.intel.com/en-us/node/469230
-                //
-                // - If the j-th eigenvalue is real,
-                //   - v(j) = VR(:,j), the j-th column of VR.
-                //
-                // - If the j-th and (j+1)-st eigenvalues form a complex conjugate pair,
-                //   - v(j)   = VR(:,j) + i*VR(:,j+1)
-                //   - v(j+1) = VR(:,j) - i*VR(:,j+1).
-                //
-                // In the C-layout case, we need the conjugates of the left
-                // eigenvectors, so the signs should be reversed.
-
-                let n = n as usize;
-                let v = vr.or(vl).unwrap();
-                let mut eigvecs: Vec<MaybeUninit<Self::Complex>> = vec_uninit(n * n);
-                let mut col = 0;
-                while col < n {
-                    if eig_im[col] == 0. {
-                        // The corresponding eigenvalue is real.
-                        for row in 0..n {
-                            let re = v[row + col * n];
-                            eigvecs[row + col * n].write(Self::complex(re, 0.));
-                        }
-                        col += 1;
-                    } else {
-                        // This is a complex conjugate pair.
-                        assert!(col + 1 < n);
-                        for row in 0..n {
-                            let re = v[row + col * n];
-                            let mut im = v[row + (col + 1) * n];
-                            if jobvl.is_calc() {
-                                im = -im;
-                            }
-                            eigvecs[row + col * n].write(Self::complex(re, im));
-                            eigvecs[row + (col + 1) * n].write(Self::complex(re, -im));
-                        }
-                        col += 2;
-                    }
-                }
-                let eigvecs = unsafe { eigvecs.assume_init() };
-
-                Ok((eigs, eigvecs))
             }
         }
     };
@@ -485,3 +621,62 @@ macro_rules! impl_eig_real {
 
 impl_eig_real!(f64, lapack_sys::dgeev_);
 impl_eig_real!(f32, lapack_sys::sgeev_);
+
+/// Reconstruct eigenvectors into complex-array
+///
+/// From LAPACK API https://software.intel.com/en-us/node/469230
+///
+/// - If the j-th eigenvalue is real,
+///   - v(j) = VR(:,j), the j-th column of VR.
+///
+/// - If the j-th and (j+1)-st eigenvalues form a complex conjugate pair,
+///   - v(j)   = VR(:,j) + i*VR(:,j+1)
+///   - v(j+1) = VR(:,j) - i*VR(:,j+1).
+///
+/// In the C-layout case, we need the conjugates of the left
+/// eigenvectors, so the signs should be reversed.
+fn reconstruct_eigenvectors<T: Scalar>(
+    take_hermite_conjugate: bool,
+    eig_im: &[T],
+    vr: &[T],
+    vc: &mut [MaybeUninit<T::Complex>],
+) {
+    let n = eig_im.len();
+    assert_eq!(vr.len(), n * n);
+    assert_eq!(vc.len(), n * n);
+
+    let mut col = 0;
+    while col < n {
+        if eig_im[col].is_zero() {
+            // The corresponding eigenvalue is real.
+            for row in 0..n {
+                let re = vr[row + col * n];
+                vc[row + col * n].write(T::complex(re, T::zero()));
+            }
+            col += 1;
+        } else {
+            // This is a complex conjugate pair.
+            assert!(col + 1 < n);
+            for row in 0..n {
+                let re = vr[row + col * n];
+                let mut im = vr[row + (col + 1) * n];
+                if take_hermite_conjugate {
+                    im = -im;
+                }
+                vc[row + col * n].write(T::complex(re, im));
+                vc[row + (col + 1) * n].write(T::complex(re, -im));
+            }
+            col += 2;
+        }
+    }
+}
+
+/// Create complex eigenvalues from real and imaginary parts.
+fn reconstruct_eigs<T: Scalar>(re: &[T], im: &[T], eigs: &mut [MaybeUninit<T::Complex>]) {
+    let n = eigs.len();
+    assert_eq!(re.len(), n);
+    assert_eq!(im.len(), n);
+    for i in 0..n {
+        eigs[i].write(T::complex(re[i], im[i]));
+    }
+}

--- a/lax/src/eig.rs
+++ b/lax/src/eig.rs
@@ -357,11 +357,11 @@ macro_rules! impl_eig_work_r {
 
                 if let Some(v) = self.vr_l.as_ref() {
                     let v = unsafe { v.slice_assume_init_ref() };
-                    reconstruct_eigenvectors(false, eigs_im, v, self.vc_l.as_mut().unwrap());
+                    reconstruct_eigenvectors(true, eigs_im, v, self.vc_l.as_mut().unwrap());
                 }
                 if let Some(v) = self.vr_r.as_ref() {
                     let v = unsafe { v.slice_assume_init_ref() };
-                    reconstruct_eigenvectors(false, eigs_im, v, self.vc_l.as_mut().unwrap());
+                    reconstruct_eigenvectors(false, eigs_im, v, self.vc_r.as_mut().unwrap());
                 }
 
                 Ok(EigRef {
@@ -414,11 +414,11 @@ macro_rules! impl_eig_work_r {
 
                 if let Some(v) = self.vr_l.as_ref() {
                     let v = unsafe { v.slice_assume_init_ref() };
-                    reconstruct_eigenvectors(false, eigs_im, v, self.vc_l.as_mut().unwrap());
+                    reconstruct_eigenvectors(true, eigs_im, v, self.vc_l.as_mut().unwrap());
                 }
                 if let Some(v) = self.vr_r.as_ref() {
                     let v = unsafe { v.slice_assume_init_ref() };
-                    reconstruct_eigenvectors(false, eigs_im, v, self.vc_l.as_mut().unwrap());
+                    reconstruct_eigenvectors(false, eigs_im, v, self.vc_r.as_mut().unwrap());
                 }
 
                 Ok(Eig {

--- a/lax/src/eig.rs
+++ b/lax/src/eig.rs
@@ -4,6 +4,17 @@ use num_traits::{ToPrimitive, Zero};
 
 #[cfg_attr(doc, katexit::katexit)]
 /// Eigenvalue problem for general matrix
+///
+/// LAPACK assumes a column-major input. A row-major input can
+/// be interpreted as the transpose of a column-major input. So,
+/// for row-major inputs, we we want to solve the following,
+/// given the column-major input `A`:
+///
+///   A^T V = V Λ ⟺ V^T A = Λ V^T ⟺ conj(V)^H A = Λ conj(V)^H
+///
+/// So, in this case, the right eigenvectors are the conjugates
+/// of the left eigenvectors computed with `A`, and the
+/// eigenvalues are the eigenvalues computed with `A`.
 pub trait Eig_: Scalar {
     /// Compute right eigenvalue and eigenvectors $Ax = \lambda x$
     ///

--- a/lax/src/lib.rs
+++ b/lax/src/lib.rs
@@ -84,9 +84,10 @@ pub mod error;
 pub mod flags;
 pub mod layout;
 
+pub mod eig;
+
 mod alloc;
 mod cholesky;
-mod eig;
 mod eigh;
 mod least_squares;
 mod opnorm;
@@ -100,7 +101,7 @@ mod triangular;
 mod tridiagonal;
 
 pub use self::cholesky::*;
-pub use self::eig::*;
+pub use self::eig::Eig_;
 pub use self::eigh::*;
 pub use self::flags::*;
 pub use self::least_squares::*;


### PR DESCRIPTION
Revival of #241, for #168

- This PR only adds new API without changing existing ones

New API
--------

- `lax::eig::EigWork` for managing working memory
- `lax::eig::EigOwned` and `lax::eig::EigRef` for its result
- `VecAssumeInit::slice_assume_init_ref`