### PR TITLE
Safe `lax::vec_uninit`

### DIFF
--- a/lax/src/alloc.rs
+++ b/lax/src/alloc.rs
@@ -1,0 +1,60 @@
+use cauchy::*;
+use std::mem::MaybeUninit;
+
+/// Helper for getting pointer of slice
+pub(crate) trait AsPtr: Sized {
+    type Elem;
+    fn as_ptr(vec: &[Self]) -> *const Self::Elem;
+    fn as_mut_ptr(vec: &mut [Self]) -> *mut Self::Elem;
+}
+
+macro_rules! impl_as_ptr {
+    ($target:ty, $elem:ty) => {
+        impl AsPtr for $target {
+            type Elem = $elem;
+            fn as_ptr(vec: &[Self]) -> *const Self::Elem {
+                vec.as_ptr() as *const _
+            }
+            fn as_mut_ptr(vec: &mut [Self]) -> *mut Self::Elem {
+                vec.as_mut_ptr() as *mut _
+            }
+        }
+    };
+}
+impl_as_ptr!(i32, i32);
+impl_as_ptr!(f32, f32);
+impl_as_ptr!(f64, f64);
+impl_as_ptr!(c32, lapack_sys::__BindgenComplex<f32>);
+impl_as_ptr!(c64, lapack_sys::__BindgenComplex<f64>);
+impl_as_ptr!(MaybeUninit<i32>, i32);
+impl_as_ptr!(MaybeUninit<f32>, f32);
+impl_as_ptr!(MaybeUninit<f64>, f64);
+impl_as_ptr!(MaybeUninit<c32>, lapack_sys::__BindgenComplex<f32>);
+impl_as_ptr!(MaybeUninit<c64>, lapack_sys::__BindgenComplex<f64>);
+
+pub(crate) trait VecAssumeInit {
+    type Target;
+    unsafe fn assume_init(self) -> Self::Target;
+}
+
+impl<T> VecAssumeInit for Vec<MaybeUninit<T>> {
+    type Target = Vec<T>;
+    unsafe fn assume_init(self) -> Self::Target {
+        // FIXME use Vec::into_raw_parts instead after stablized
+        // https://doc.rust-lang.org/std/vec/struct.Vec.html#method.into_raw_parts
+        let mut me = std::mem::ManuallyDrop::new(self);
+        Vec::from_raw_parts(me.as_mut_ptr() as *mut T, me.len(), me.capacity())
+    }
+}
+
+/// Create a vector without initialization
+///
+/// Safety
+/// ------
+/// - Memory is not initialized. Do not read the memory before write.
+///
+pub(crate) unsafe fn vec_uninit<T: Sized>(n: usize) -> Vec<MaybeUninit<T>> {
+    let mut v = Vec::with_capacity(n);
+    v.set_len(n);
+    v
+}

--- a/lax/src/alloc.rs
+++ b/lax/src/alloc.rs
@@ -53,8 +53,10 @@ impl<T> VecAssumeInit for Vec<MaybeUninit<T>> {
 /// ------
 /// - Memory is not initialized. Do not read the memory before write.
 ///
-pub(crate) unsafe fn vec_uninit<T: Sized>(n: usize) -> Vec<MaybeUninit<T>> {
+pub(crate) fn vec_uninit<T: Sized>(n: usize) -> Vec<MaybeUninit<T>> {
     let mut v = Vec::with_capacity(n);
-    v.set_len(n);
+    unsafe {
+        v.set_len(n);
+    }
     v
 }

--- a/lax/src/eig.rs
+++ b/lax/src/eig.rs
@@ -48,13 +48,13 @@ macro_rules! impl_eig_complex {
                 } else {
                     (JobEv::None, JobEv::None)
                 };
-                let mut eigs: Vec<MaybeUninit<Self>> = unsafe { vec_uninit(n as usize) };
-                let mut rwork: Vec<MaybeUninit<Self::Real>> = unsafe { vec_uninit(2 * n as usize) };
+                let mut eigs: Vec<MaybeUninit<Self>> = vec_uninit(n as usize);
+                let mut rwork: Vec<MaybeUninit<Self::Real>> = vec_uninit(2 * n as usize);
 
                 let mut vl: Option<Vec<MaybeUninit<Self>>> =
-                    jobvl.then(|| unsafe { vec_uninit((n * n) as usize) });
+                    jobvl.then(|| vec_uninit((n * n) as usize));
                 let mut vr: Option<Vec<MaybeUninit<Self>>> =
-                    jobvr.then(|| unsafe { vec_uninit((n * n) as usize) });
+                    jobvr.then(|| vec_uninit((n * n) as usize));
 
                 // calc work size
                 let mut info = 0;
@@ -81,7 +81,7 @@ macro_rules! impl_eig_complex {
 
                 // actal ev
                 let lwork = work_size[0].to_usize().unwrap();
-                let mut work: Vec<MaybeUninit<Self>> = unsafe { vec_uninit(lwork) };
+                let mut work: Vec<MaybeUninit<Self>> = vec_uninit(lwork);
                 let lwork = lwork as i32;
                 unsafe {
                     $ev(
@@ -156,13 +156,13 @@ macro_rules! impl_eig_real {
                 } else {
                     (JobEv::None, JobEv::None)
                 };
-                let mut eig_re: Vec<MaybeUninit<Self>> = unsafe { vec_uninit(n as usize) };
-                let mut eig_im: Vec<MaybeUninit<Self>> = unsafe { vec_uninit(n as usize) };
+                let mut eig_re: Vec<MaybeUninit<Self>> = vec_uninit(n as usize);
+                let mut eig_im: Vec<MaybeUninit<Self>> = vec_uninit(n as usize);
 
                 let mut vl: Option<Vec<MaybeUninit<Self>>> =
-                    jobvl.then(|| unsafe { vec_uninit((n * n) as usize) });
+                    jobvl.then(|| vec_uninit((n * n) as usize));
                 let mut vr: Option<Vec<MaybeUninit<Self>>> =
-                    jobvr.then(|| unsafe { vec_uninit((n * n) as usize) });
+                    jobvr.then(|| vec_uninit((n * n) as usize));
 
                 // calc work size
                 let mut info = 0;
@@ -189,7 +189,7 @@ macro_rules! impl_eig_real {
 
                 // actual ev
                 let lwork = work_size[0].to_usize().unwrap();
-                let mut work: Vec<MaybeUninit<Self>> = unsafe { vec_uninit(lwork) };
+                let mut work: Vec<MaybeUninit<Self>> = vec_uninit(lwork);
                 let lwork = lwork as i32;
                 unsafe {
                     $ev(
@@ -244,7 +244,7 @@ macro_rules! impl_eig_real {
 
                 let n = n as usize;
                 let v = vr.or(vl).unwrap();
-                let mut eigvecs: Vec<MaybeUninit<Self::Complex>> = unsafe { vec_uninit(n * n) };
+                let mut eigvecs: Vec<MaybeUninit<Self::Complex>> = vec_uninit(n * n);
                 let mut col = 0;
                 while col < n {
                     if eig_im[col] == 0. {

--- a/lax/src/eigh.rs
+++ b/lax/src/eigh.rs
@@ -58,10 +58,10 @@ macro_rules! impl_eigh {
                 assert_eq!(layout.len(), layout.lda());
                 let n = layout.len();
                 let jobz = if calc_v { JobEv::All } else { JobEv::None };
-                let mut eigs: Vec<MaybeUninit<Self::Real>> = unsafe { vec_uninit(n as usize) };
+                let mut eigs: Vec<MaybeUninit<Self::Real>> = vec_uninit(n as usize);
 
                 $(
-                let mut $rwork_ident: Vec<MaybeUninit<Self::Real>> = unsafe { vec_uninit(3 * n as usize - 2 as usize) };
+                let mut $rwork_ident: Vec<MaybeUninit<Self::Real>> = vec_uninit(3 * n as usize - 2 as usize);
                 )*
 
                 // calc work size
@@ -85,7 +85,7 @@ macro_rules! impl_eigh {
 
                 // actual ev
                 let lwork = work_size[0].to_usize().unwrap();
-                let mut work: Vec<MaybeUninit<Self>> = unsafe { vec_uninit(lwork) };
+                let mut work: Vec<MaybeUninit<Self>> = vec_uninit(lwork);
                 let lwork = lwork as i32;
                 unsafe {
                     $ev(
@@ -117,10 +117,10 @@ macro_rules! impl_eigh {
                 assert_eq!(layout.len(), layout.lda());
                 let n = layout.len();
                 let jobz = if calc_v { JobEv::All } else { JobEv::None };
-                let mut eigs: Vec<MaybeUninit<Self::Real>> = unsafe { vec_uninit(n as usize) };
+                let mut eigs: Vec<MaybeUninit<Self::Real>> = vec_uninit(n as usize);
 
                 $(
-                let mut $rwork_ident: Vec<MaybeUninit<Self::Real>> = unsafe { vec_uninit(3 * n as usize - 2) };
+                let mut $rwork_ident: Vec<MaybeUninit<Self::Real>> = vec_uninit(3 * n as usize - 2);
                 )*
 
                 // calc work size
@@ -147,7 +147,7 @@ macro_rules! impl_eigh {
 
                 // actual evg
                 let lwork = work_size[0].to_usize().unwrap();
-                let mut work: Vec<MaybeUninit<Self>> = unsafe { vec_uninit(lwork) };
+                let mut work: Vec<MaybeUninit<Self>> = vec_uninit(lwork);
                 let lwork = lwork as i32;
                 unsafe {
                     $evg(

--- a/lax/src/layout.rs
+++ b/lax/src/layout.rs
@@ -202,7 +202,7 @@ pub fn transpose<T: Copy>(layout: MatrixLayout, input: &[T]) -> (MatrixLayout, V
     let n = n as usize;
     assert_eq!(input.len(), m * n);
 
-    let mut out: Vec<MaybeUninit<T>> = unsafe { vec_uninit(m * n) };
+    let mut out: Vec<MaybeUninit<T>> = vec_uninit(m * n);
 
     match layout {
         MatrixLayout::C { .. } => {

--- a/lax/src/least_squares.rs
+++ b/lax/src/least_squares.rs
@@ -91,7 +91,7 @@ macro_rules! impl_least_squares {
                 };
 
                 let rcond: Self::Real = -1.;
-                let mut singular_values: Vec<MaybeUninit<Self::Real>> = unsafe { vec_uninit( k as usize) };
+                let mut singular_values: Vec<MaybeUninit<Self::Real>> = vec_uninit( k as usize);
                 let mut rank: i32 = 0;
 
                 // eval work size
@@ -124,12 +124,12 @@ macro_rules! impl_least_squares {
 
                 // calc
                 let lwork = work_size[0].to_usize().unwrap();
-                let mut work: Vec<MaybeUninit<Self>> = unsafe { vec_uninit(lwork) };
+                let mut work: Vec<MaybeUninit<Self>> = vec_uninit(lwork);
                 let liwork = iwork_size[0].to_usize().unwrap();
-                let mut iwork: Vec<MaybeUninit<i32>> = unsafe { vec_uninit(liwork) };
+                let mut iwork: Vec<MaybeUninit<i32>> = vec_uninit(liwork);
                 $(
                 let lrwork = $rwork[0].to_usize().unwrap();
-                let mut $rwork: Vec<MaybeUninit<Self::Real>> = unsafe { vec_uninit(lrwork) };
+                let mut $rwork: Vec<MaybeUninit<Self::Real>> = vec_uninit(lrwork);
                 )*
                 unsafe {
                     $gelsd(

--- a/lax/src/lib.rs
+++ b/lax/src/lib.rs
@@ -84,6 +84,7 @@ pub mod error;
 pub mod flags;
 pub mod layout;
 
+mod alloc;
 mod cholesky;
 mod eig;
 mod eigh;
@@ -113,6 +114,7 @@ pub use self::svddc::*;
 pub use self::triangular::*;
 pub use self::tridiagonal::*;
 
+use self::alloc::*;
 use cauchy::*;
 use std::mem::MaybeUninit;
 
@@ -140,61 +142,3 @@ impl Lapack for f32 {}
 impl Lapack for f64 {}
 impl Lapack for c32 {}
 impl Lapack for c64 {}
-
-/// Helper for getting pointer of slice
-pub(crate) trait AsPtr: Sized {
-    type Elem;
-    fn as_ptr(vec: &[Self]) -> *const Self::Elem;
-    fn as_mut_ptr(vec: &mut [Self]) -> *mut Self::Elem;
-}
-
-macro_rules! impl_as_ptr {
-    ($target:ty, $elem:ty) => {
-        impl AsPtr for $target {
-            type Elem = $elem;
-            fn as_ptr(vec: &[Self]) -> *const Self::Elem {
-                vec.as_ptr() as *const _
-            }
-            fn as_mut_ptr(vec: &mut [Self]) -> *mut Self::Elem {
-                vec.as_mut_ptr() as *mut _
-            }
-        }
-    };
-}
-impl_as_ptr!(i32, i32);
-impl_as_ptr!(f32, f32);
-impl_as_ptr!(f64, f64);
-impl_as_ptr!(c32, lapack_sys::__BindgenComplex<f32>);
-impl_as_ptr!(c64, lapack_sys::__BindgenComplex<f64>);
-impl_as_ptr!(MaybeUninit<i32>, i32);
-impl_as_ptr!(MaybeUninit<f32>, f32);
-impl_as_ptr!(MaybeUninit<f64>, f64);
-impl_as_ptr!(MaybeUninit<c32>, lapack_sys::__BindgenComplex<f32>);
-impl_as_ptr!(MaybeUninit<c64>, lapack_sys::__BindgenComplex<f64>);
-
-pub(crate) trait VecAssumeInit {
-    type Target;
-    unsafe fn assume_init(self) -> Self::Target;
-}
-
-impl<T> VecAssumeInit for Vec<MaybeUninit<T>> {
-    type Target = Vec<T>;
-    unsafe fn assume_init(self) -> Self::Target {
-        // FIXME use Vec::into_raw_parts instead after stablized
-        // https://doc.rust-lang.org/std/vec/struct.Vec.html#method.into_raw_parts
-        let mut me = std::mem::ManuallyDrop::new(self);
-        Vec::from_raw_parts(me.as_mut_ptr() as *mut T, me.len(), me.capacity())
-    }
-}
-
-/// Create a vector without initialization
-///
-/// Safety
-/// ------
-/// - Memory is not initialized. Do not read the memory before write.
-///
-unsafe fn vec_uninit<T: Sized>(n: usize) -> Vec<MaybeUninit<T>> {
-    let mut v = Vec::with_capacity(n);
-    v.set_len(n);
-    v
-}

--- a/lax/src/opnorm.rs
+++ b/lax/src/opnorm.rs
@@ -19,7 +19,7 @@ macro_rules! impl_opnorm {
                     MatrixLayout::C { .. } => t.transpose(),
                 };
                 let mut work: Vec<MaybeUninit<Self::Real>> = if matches!(t, NormType::Infinity) {
-                    unsafe { vec_uninit(m as usize) }
+                    vec_uninit(m as usize)
                 } else {
                     Vec::new()
                 };

--- a/lax/src/qr.rs
+++ b/lax/src/qr.rs
@@ -25,7 +25,7 @@ macro_rules! impl_qr {
                 let m = l.lda();
                 let n = l.len();
                 let k = m.min(n);
-                let mut tau = unsafe { vec_uninit(k as usize) };
+                let mut tau = vec_uninit(k as usize);
 
                 // eval work size
                 let mut info = 0;
@@ -62,7 +62,7 @@ macro_rules! impl_qr {
 
                 // calc
                 let lwork = work_size[0].to_usize().unwrap();
-                let mut work: Vec<MaybeUninit<Self>> = unsafe { vec_uninit(lwork) };
+                let mut work: Vec<MaybeUninit<Self>> = vec_uninit(lwork);
                 unsafe {
                     match l {
                         MatrixLayout::F { .. } => {
@@ -136,7 +136,7 @@ macro_rules! impl_qr {
 
                 // calc
                 let lwork = work_size[0].to_usize().unwrap();
-                let mut work: Vec<MaybeUninit<Self>> = unsafe { vec_uninit(lwork) };
+                let mut work: Vec<MaybeUninit<Self>> = vec_uninit(lwork);
                 unsafe {
                     match l {
                         MatrixLayout::F { .. } => $gqr(

--- a/lax/src/rcond.rs
+++ b/lax/src/rcond.rs
@@ -17,8 +17,8 @@ macro_rules! impl_rcond_real {
                 let mut rcond = Self::Real::zero();
                 let mut info = 0;
 
-                let mut work: Vec<MaybeUninit<Self>> = unsafe { vec_uninit(4 * n as usize) };
-                let mut iwork: Vec<MaybeUninit<i32>> = unsafe { vec_uninit(n as usize) };
+                let mut work: Vec<MaybeUninit<Self>> = vec_uninit(4 * n as usize);
+                let mut iwork: Vec<MaybeUninit<i32>> = vec_uninit(n as usize);
                 let norm_type = match l {
                     MatrixLayout::C { .. } => NormType::Infinity,
                     MatrixLayout::F { .. } => NormType::One,
@@ -54,8 +54,8 @@ macro_rules! impl_rcond_complex {
                 let (n, _) = l.size();
                 let mut rcond = Self::Real::zero();
                 let mut info = 0;
-                let mut work: Vec<MaybeUninit<Self>> = unsafe { vec_uninit(2 * n as usize) };
-                let mut rwork: Vec<MaybeUninit<Self::Real>> = unsafe { vec_uninit(2 * n as usize) };
+                let mut work: Vec<MaybeUninit<Self>> = vec_uninit(2 * n as usize);
+                let mut rwork: Vec<MaybeUninit<Self::Real>> = vec_uninit(2 * n as usize);
                 let norm_type = match l {
                     MatrixLayout::C { .. } => NormType::Infinity,
                     MatrixLayout::F { .. } => NormType::One,

--- a/lax/src/solve.rs
+++ b/lax/src/solve.rs
@@ -75,7 +75,7 @@ macro_rules! impl_solve {
                     return Ok(Vec::new());
                 }
                 let k = ::std::cmp::min(row, col);
-                let mut ipiv = unsafe { vec_uninit(k as usize) };
+                let mut ipiv = vec_uninit(k as usize);
                 let mut info = 0;
                 unsafe {
                     $getrf(
@@ -117,7 +117,7 @@ macro_rules! impl_solve {
 
                 // actual
                 let lwork = work_size[0].to_usize().unwrap();
-                let mut work: Vec<MaybeUninit<Self>> = unsafe { vec_uninit(lwork) };
+                let mut work: Vec<MaybeUninit<Self>> = vec_uninit(lwork);
                 unsafe {
                     $getri(
                         &l.len(),

--- a/lax/src/solveh.rs
+++ b/lax/src/solveh.rs
@@ -58,7 +58,7 @@ macro_rules! impl_solveh {
         impl Solveh_ for $scalar {
             fn bk(l: MatrixLayout, uplo: UPLO, a: &mut [Self]) -> Result<Pivot> {
                 let (n, _) = l.size();
-                let mut ipiv = unsafe { vec_uninit(n as usize) };
+                let mut ipiv = vec_uninit(n as usize);
                 if n == 0 {
                     return Ok(Vec::new());
                 }
@@ -82,7 +82,7 @@ macro_rules! impl_solveh {
 
                 // actual
                 let lwork = work_size[0].to_usize().unwrap();
-                let mut work: Vec<MaybeUninit<Self>> = unsafe { vec_uninit(lwork) };
+                let mut work: Vec<MaybeUninit<Self>> = vec_uninit(lwork);
                 unsafe {
                     $trf(
                         uplo.as_ptr(),
@@ -103,7 +103,7 @@ macro_rules! impl_solveh {
             fn invh(l: MatrixLayout, uplo: UPLO, a: &mut [Self], ipiv: &Pivot) -> Result<()> {
                 let (n, _) = l.size();
                 let mut info = 0;
-                let mut work: Vec<MaybeUninit<Self>> = unsafe { vec_uninit(n as usize) };
+                let mut work: Vec<MaybeUninit<Self>> = vec_uninit(n as usize);
                 unsafe {
                     $tri(
                         uplo.as_ptr(),

--- a/lax/src/svd.rs
+++ b/lax/src/svd.rs
@@ -51,23 +51,23 @@ macro_rules! impl_svd {
 
                 let m = l.lda();
                 let mut u = match ju {
-                    JobSvd::All => Some(unsafe { vec_uninit( (m * m) as usize) }),
+                    JobSvd::All => Some(vec_uninit( (m * m) as usize)),
                     JobSvd::None => None,
                     _ => unimplemented!("SVD with partial vector output is not supported yet")
                 };
 
                 let n = l.len();
                 let mut vt = match jvt {
-                    JobSvd::All => Some(unsafe { vec_uninit( (n * n) as usize) }),
+                    JobSvd::All => Some(vec_uninit( (n * n) as usize)),
                     JobSvd::None => None,
                     _ => unimplemented!("SVD with partial vector output is not supported yet")
                 };
 
                 let k = std::cmp::min(m, n);
-                let mut s = unsafe { vec_uninit( k as usize) };
+                let mut s = vec_uninit( k as usize);
 
                 $(
-                let mut $rwork_ident: Vec<MaybeUninit<Self::Real>> = unsafe { vec_uninit( 5 * k as usize) };
+                let mut $rwork_ident: Vec<MaybeUninit<Self::Real>> = vec_uninit(5 * k as usize);
                 )*
 
                 // eval work size
@@ -96,7 +96,7 @@ macro_rules! impl_svd {
 
                 // calc
                 let lwork = work_size[0].to_usize().unwrap();
-                let mut work: Vec<MaybeUninit<Self>> = unsafe { vec_uninit( lwork) };
+                let mut work: Vec<MaybeUninit<Self>> = vec_uninit(lwork);
                 unsafe {
                     $gesvd(
                         ju.as_ptr(),

--- a/lax/src/svddc.rs
+++ b/lax/src/svddc.rs
@@ -30,7 +30,7 @@ macro_rules! impl_svddc {
                 let m = l.lda();
                 let n = l.len();
                 let k = m.min(n);
-                let mut s = unsafe { vec_uninit( k as usize) };
+                let mut s = vec_uninit(k as usize);
 
                 let (u_col, vt_row) = match jobz {
                     JobSvd::All | JobSvd::None => (m, n),
@@ -38,12 +38,12 @@ macro_rules! impl_svddc {
                 };
                 let (mut u, mut vt) = match jobz {
                     JobSvd::All => (
-                        Some(unsafe { vec_uninit( (m * m) as usize) }),
-                        Some(unsafe { vec_uninit( (n * n) as usize) }),
+                        Some(vec_uninit((m * m) as usize)),
+                        Some(vec_uninit((n * n) as usize)),
                     ),
                     JobSvd::Some => (
-                        Some(unsafe { vec_uninit( (m * u_col) as usize) }),
-                        Some(unsafe { vec_uninit( (n * vt_row) as usize) }),
+                        Some(vec_uninit((m * u_col) as usize)),
+                        Some(vec_uninit((n * vt_row) as usize)),
                     ),
                     JobSvd::None => (None, None),
                 };
@@ -55,12 +55,12 @@ macro_rules! impl_svddc {
                     JobSvd::None => 7 * mn,
                     _ => std::cmp::max(5*mn*mn + 5*mn, 2*mx*mn + 2*mn*mn + mn),
                 };
-                let mut $rwork_ident: Vec<MaybeUninit<Self::Real>> = unsafe { vec_uninit( lrwork) };
+                let mut $rwork_ident: Vec<MaybeUninit<Self::Real>> = vec_uninit(lrwork);
                 )*
 
                 // eval work size
                 let mut info = 0;
-                let mut iwork: Vec<MaybeUninit<i32>> = unsafe { vec_uninit( 8 * k as usize) };
+                let mut iwork: Vec<MaybeUninit<i32>> = vec_uninit(8 * k as usize);
                 let mut work_size = [Self::zero()];
                 unsafe {
                     $gesdd(
@@ -85,7 +85,7 @@ macro_rules! impl_svddc {
 
                 // do svd
                 let lwork = work_size[0].to_usize().unwrap();
-                let mut work: Vec<MaybeUninit<Self>> = unsafe { vec_uninit( lwork) };
+                let mut work: Vec<MaybeUninit<Self>> = vec_uninit(lwork);
                 unsafe {
                     $gesdd(
                         jobz.as_ptr(),

--- a/lax/src/tridiagonal.rs
+++ b/lax/src/tridiagonal.rs
@@ -152,8 +152,8 @@ macro_rules! impl_tridiagonal {
         impl Tridiagonal_ for $scalar {
             fn lu_tridiagonal(mut a: Tridiagonal<Self>) -> Result<LUFactorizedTridiagonal<Self>> {
                 let (n, _) = a.l.size();
-                let mut du2 = unsafe { vec_uninit( (n - 2) as usize) };
-                let mut ipiv = unsafe { vec_uninit( n as usize) };
+                let mut du2 = vec_uninit( (n - 2) as usize);
+                let mut ipiv = vec_uninit( n as usize);
                 // We have to calc one-norm before LU factorization
                 let a_opnorm_one = a.opnorm_one();
                 let mut info = 0;
@@ -182,9 +182,9 @@ macro_rules! impl_tridiagonal {
             fn rcond_tridiagonal(lu: &LUFactorizedTridiagonal<Self>) -> Result<Self::Real> {
                 let (n, _) = lu.a.l.size();
                 let ipiv = &lu.ipiv;
-                let mut work: Vec<MaybeUninit<Self>> = unsafe { vec_uninit( 2 * n as usize) };
+                let mut work: Vec<MaybeUninit<Self>> = vec_uninit(2 * n as usize);
                 $(
-                let mut $iwork: Vec<MaybeUninit<i32>> = unsafe { vec_uninit( n as usize) };
+                let mut $iwork: Vec<MaybeUninit<i32>> = vec_uninit(n as usize);
                 )*
                 let mut rcond = Self::Real::zero();
                 let mut info = 0;


### PR DESCRIPTION
Split from #333 

- Create `lax::alloc` private submodule
- Remove `unsafe` marker from `lax::vec_uninit`