### PR TITLE
`cargo check --all-targets` on CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,6 +16,15 @@ jobs:
         command: fmt
         args: -- --check
 
+  check:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions-rs/cargo@v1
+      with:
+        command: check
+        args: --all-targets
+
   clippy:
     runs-on: ubuntu-22.04
     steps:

--- a/ndarray-linalg/benches/svd.rs
+++ b/ndarray-linalg/benches/svd.rs
@@ -62,37 +62,37 @@ fn svddc_small(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::new("C", n), &n, |b, n| {
             let a: Array2<f64> = random((*n, *n));
             b.iter(|| {
-                let _ = a.svddc(UVTFlag::None).unwrap();
+                let _ = a.svddc(JobSvd::None).unwrap();
             })
         });
         group.bench_with_input(BenchmarkId::new("F", n), &n, |b, n| {
             let a: Array2<f64> = random((*n, *n).f());
             b.iter(|| {
-                let _ = a.svddc(UVTFlag::None).unwrap();
+                let _ = a.svddc(JobSvd::None).unwrap();
             })
         });
         group.bench_with_input(BenchmarkId::new("some/C", n), &n, |b, n| {
             let a: Array2<f64> = random((*n, *n));
             b.iter(|| {
-                let _ = a.svddc(UVTFlag::Some).unwrap();
+                let _ = a.svddc(JobSvd::Some).unwrap();
             })
         });
         group.bench_with_input(BenchmarkId::new("some/F", n), &n, |b, n| {
             let a: Array2<f64> = random((*n, *n).f());
             b.iter(|| {
-                let _ = a.svddc(UVTFlag::Some).unwrap();
+                let _ = a.svddc(JobSvd::Some).unwrap();
             })
         });
         group.bench_with_input(BenchmarkId::new("full/C", n), &n, |b, n| {
             let a: Array2<f64> = random((*n, *n));
             b.iter(|| {
-                let _ = a.svddc(UVTFlag::Full).unwrap();
+                let _ = a.svddc(JobSvd::All).unwrap();
             })
         });
         group.bench_with_input(BenchmarkId::new("full/F", n), &n, |b, n| {
             let a: Array2<f64> = random((*n, *n).f());
             b.iter(|| {
-                let _ = a.svddc(UVTFlag::Full).unwrap();
+                let _ = a.svddc(JobSvd::All).unwrap();
             })
         });
     }


### PR DESCRIPTION
`ndarray_linalg/benches` are not checked on CI. This allows a miss-checking at #331 