### PR TITLE
Merge `Eig_` trait into `Lapack` trait

### DIFF
--- a/lax/src/eig.rs
+++ b/lax/src/eig.rs
@@ -1,4 +1,12 @@
 //! Eigenvalue problem for general matricies
+//!
+//! LAPACK correspondance
+//! ----------------------
+//!
+//! | f32   | f64   | c32   | c64   |
+//! |:------|:------|:------|:------|
+//! | sgeev | dgeev | cgeev | zgeev |
+//!
 
 use crate::{error::*, layout::MatrixLayout, *};
 use cauchy::*;

--- a/lax/src/eig.rs
+++ b/lax/src/eig.rs
@@ -40,44 +40,6 @@ use num_traits::{ToPrimitive, Zero};
 /// A^\dagger V = V Λ ⟺ V^\dagger A = Λ V^\dagger
 /// $$
 ///
-pub trait Eig_: Scalar {
-    /// Compute right eigenvalue and eigenvectors $Ax = \lambda x$
-    ///
-    /// LAPACK correspondance
-    /// ----------------------
-    ///
-    /// | f32   | f64   | c32   | c64   |
-    /// |:------|:------|:------|:------|
-    /// | sgeev | dgeev | cgeev | zgeev |
-    ///
-    fn eig(
-        calc_v: bool,
-        l: MatrixLayout,
-        a: &mut [Self],
-    ) -> Result<(Vec<Self::Complex>, Vec<Self::Complex>)>;
-}
-
-macro_rules! impl_eig {
-    ($s:ty) => {
-        impl Eig_ for $s {
-            fn eig(
-                calc_v: bool,
-                l: MatrixLayout,
-                a: &mut [Self],
-            ) -> Result<(Vec<Self::Complex>, Vec<Self::Complex>)> {
-                let work = EigWork::<$s>::new(calc_v, l)?;
-                let EigOwned { eigs, vr, vl } = work.eval(a)?;
-                Ok((eigs, vr.or(vl).unwrap_or_default()))
-            }
-        }
-    };
-}
-impl_eig!(c64);
-impl_eig!(c32);
-impl_eig!(f64);
-impl_eig!(f32);
-
-/// Working memory for [Eig_]
 #[non_exhaustive]
 pub struct EigWork<T: Scalar> {
     /// Problem size

--- a/lax/src/lib.rs
+++ b/lax/src/lib.rs
@@ -101,7 +101,6 @@ mod triangular;
 mod tridiagonal;
 
 pub use self::cholesky::*;
-pub use self::eig::Eig_;
 pub use self::eigh::*;
 pub use self::flags::*;
 pub use self::least_squares::*;
@@ -115,7 +114,7 @@ pub use self::svddc::*;
 pub use self::triangular::*;
 pub use self::tridiagonal::*;
 
-use self::alloc::*;
+use self::{alloc::*, error::*, layout::*};
 use cauchy::*;
 use std::mem::MaybeUninit;
 
@@ -130,16 +129,37 @@ pub trait Lapack:
     + Solve_
     + Solveh_
     + Cholesky_
-    + Eig_
     + Eigh_
     + Triangular_
     + Tridiagonal_
     + Rcond_
     + LeastSquaresSvdDivideConquer_
 {
+    /// Compute right eigenvalue and eigenvectors
+    fn eig(
+        calc_v: bool,
+        l: MatrixLayout,
+        a: &mut [Self],
+    ) -> Result<(Vec<Self::Complex>, Vec<Self::Complex>)>;
 }
 
-impl Lapack for f32 {}
-impl Lapack for f64 {}
-impl Lapack for c32 {}
-impl Lapack for c64 {}
+macro_rules! impl_lapack {
+    ($s:ty) => {
+        impl Lapack for $s {
+            fn eig(
+                calc_v: bool,
+                l: MatrixLayout,
+                a: &mut [Self],
+            ) -> Result<(Vec<Self::Complex>, Vec<Self::Complex>)> {
+                use eig::*;
+                let work = EigWork::<$s>::new(calc_v, l)?;
+                let EigOwned { eigs, vr, vl } = work.eval(a)?;
+                Ok((eigs, vr.or(vl).unwrap_or_default()))
+            }
+        }
+    };
+}
+impl_lapack!(c64);
+impl_lapack!(c32);
+impl_lapack!(f64);
+impl_lapack!(f32);

--- a/lax/src/lib.rs
+++ b/lax/src/lib.rs
@@ -58,7 +58,7 @@
 //! According to the property input metrix,
 //! there are several types of eigenvalue problem API
 //!
-//! - [Eig_] trait provides methods for eigenvalue problem for general matrix.
+//! - [eig] module for eigenvalue problem for general matrix.
 //! - [Eigh_] trait provides methods for eigenvalue problem for symmetric/hermite matrix.
 //!
 //! Singular Value Decomposition
@@ -146,6 +146,7 @@ pub trait Lapack:
 macro_rules! impl_lapack {
     ($s:ty) => {
         impl Lapack for $s {
+            /// Compute right eigenvalue and eigenvectors
             fn eig(
                 calc_v: bool,
                 l: MatrixLayout,


### PR DESCRIPTION
Implementation of `Eig_` has been split into `EigWork` in #333. This PR merges yielded thin wrapper code of `Eig_` into `Lapack` trait.