### PR TITLE
Deny `rustdoc::private_intra_doc_links` lint

### DIFF
--- a/lax/src/eigh.rs
+++ b/lax/src/eigh.rs
@@ -1,4 +1,4 @@
-//! Eigenvalue problem for symmetric/Hermite matricies
+//! Eigenvalue problem for symmetric/Hermitian matricies
 //!
 //! LAPACK correspondance
 //! ----------------------

--- a/lax/src/eigh_generalized.rs
+++ b/lax/src/eigh_generalized.rs
@@ -1,4 +1,4 @@
-//! Compute generalized right eigenvalue and eigenvectors
+//! Generalized eigenvalue problem for symmetric/Hermitian matrices
 //!
 //! LAPACK correspondance
 //! ----------------------

--- a/lax/src/lib.rs
+++ b/lax/src/lib.rs
@@ -72,7 +72,7 @@
 //!   for solving least square problem by SVD
 //!
 
-#![deny(rustdoc::broken_intra_doc_links)]
+#![deny(rustdoc::broken_intra_doc_links, rustdoc::private_intra_doc_links)]
 
 #[cfg(any(feature = "intel-mkl-system", feature = "intel-mkl-static"))]
 extern crate intel_mkl_src as _src;

--- a/lax/src/lib.rs
+++ b/lax/src/lib.rs
@@ -88,11 +88,11 @@ pub mod flags;
 pub mod layout;
 
 pub mod eig;
+pub mod eigh;
+pub mod eigh_generalized;
 
 mod alloc;
 mod cholesky;
-mod eigh;
-mod eigh_generalized;
 mod least_squares;
 mod opnorm;
 mod qr;
@@ -105,8 +105,6 @@ mod triangular;
 mod tridiagonal;
 
 pub use self::cholesky::*;
-pub use self::eigh::*;
-pub use self::eigh_generalized::*;
 pub use self::flags::*;
 pub use self::least_squares::*;
 pub use self::opnorm::*;

--- a/ndarray-linalg/src/lib.rs
+++ b/ndarray-linalg/src/lib.rs
@@ -44,7 +44,7 @@
     clippy::type_complexity,
     clippy::ptr_arg
 )]
-#![deny(rustdoc::broken_intra_doc_links)]
+#![deny(rustdoc::broken_intra_doc_links, rustdoc::private_intra_doc_links)]
 
 #[macro_use]
 extern crate ndarray;


### PR DESCRIPTION
- Submodules `eigh` and `eigh_generalized` are now public