### PR TITLE
use platform dependent c_char instead of hardcoded i8

### DIFF
--- a/lax/Cargo.toml
+++ b/lax/Cargo.toml
@@ -34,6 +34,7 @@ cauchy = "0.4.0"
 num-traits = "0.2.14"
 lapack-sys = "0.14.0"
 katexit = "0.1.2"
+libc = "0.2.142"
 
 [dependencies.intel-mkl-src]
 version = "0.8.1"

--- a/lax/Cargo.toml
+++ b/lax/Cargo.toml
@@ -34,7 +34,6 @@ cauchy = "0.4.0"
 num-traits = "0.2.14"
 lapack-sys = "0.14.0"
 katexit = "0.1.2"
-libc = "0.2.142"
 
 [dependencies.intel-mkl-src]
 version = "0.8.1"

--- a/lax/src/flags.rs
+++ b/lax/src/flags.rs
@@ -17,8 +17,8 @@ impl UPLO {
     }
 
     /// To use Fortran LAPACK API in lapack-sys crate
-    pub fn as_ptr(&self) -> *const i8 {
-        self as *const UPLO as *const i8
+    pub fn as_ptr(&self) -> *const libc::c_char {
+        self as *const UPLO as *const libc::c_char
     }
 }
 
@@ -32,8 +32,8 @@ pub enum Transpose {
 
 impl Transpose {
     /// To use Fortran LAPACK API in lapack-sys crate
-    pub fn as_ptr(&self) -> *const i8 {
-        self as *const Transpose as *const i8
+    pub fn as_ptr(&self) -> *const libc::c_char {
+        self as *const Transpose as *const libc::c_char
     }
 }
 
@@ -55,8 +55,8 @@ impl NormType {
     }
 
     /// To use Fortran LAPACK API in lapack-sys crate
-    pub fn as_ptr(&self) -> *const i8 {
-        self as *const NormType as *const i8
+    pub fn as_ptr(&self) -> *const libc::c_char {
+        self as *const NormType as *const libc::c_char
     }
 }
 
@@ -87,8 +87,8 @@ impl JobEv {
     }
 
     /// To use Fortran LAPACK API in lapack-sys crate
-    pub fn as_ptr(&self) -> *const i8 {
-        self as *const JobEv as *const i8
+    pub fn as_ptr(&self) -> *const libc::c_char {
+        self as *const JobEv as *const libc::c_char
     }
 }
 
@@ -117,8 +117,8 @@ impl JobSvd {
         }
     }
 
-    pub fn as_ptr(&self) -> *const i8 {
-        self as *const JobSvd as *const i8
+    pub fn as_ptr(&self) -> *const libc::c_char {
+        self as *const JobSvd as *const libc::c_char
     }
 }
 
@@ -133,7 +133,7 @@ pub enum Diag {
 }
 
 impl Diag {
-    pub fn as_ptr(&self) -> *const i8 {
-        self as *const Diag as *const i8
+    pub fn as_ptr(&self) -> *const libc::c_char {
+        self as *const Diag as *const libc::c_char
     }
 }

--- a/lax/src/flags.rs
+++ b/lax/src/flags.rs
@@ -1,4 +1,5 @@
 //! Charactor flags, e.g. `'T'`, used in LAPACK API
+use std::ffi::c_char;
 
 /// Upper/Lower specification for seveal usages
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -17,8 +18,8 @@ impl UPLO {
     }
 
     /// To use Fortran LAPACK API in lapack-sys crate
-    pub fn as_ptr(&self) -> *const libc::c_char {
-        self as *const UPLO as *const libc::c_char
+    pub fn as_ptr(&self) -> *const c_char {
+        self as *const UPLO as *const c_char
     }
 }
 
@@ -32,8 +33,8 @@ pub enum Transpose {
 
 impl Transpose {
     /// To use Fortran LAPACK API in lapack-sys crate
-    pub fn as_ptr(&self) -> *const libc::c_char {
-        self as *const Transpose as *const libc::c_char
+    pub fn as_ptr(&self) -> *const c_char {
+        self as *const Transpose as *const c_char
     }
 }
 
@@ -55,8 +56,8 @@ impl NormType {
     }
 
     /// To use Fortran LAPACK API in lapack-sys crate
-    pub fn as_ptr(&self) -> *const libc::c_char {
-        self as *const NormType as *const libc::c_char
+    pub fn as_ptr(&self) -> *const c_char {
+        self as *const NormType as *const c_char
     }
 }
 
@@ -87,8 +88,8 @@ impl JobEv {
     }
 
     /// To use Fortran LAPACK API in lapack-sys crate
-    pub fn as_ptr(&self) -> *const libc::c_char {
-        self as *const JobEv as *const libc::c_char
+    pub fn as_ptr(&self) -> *const c_char {
+        self as *const JobEv as *const c_char
     }
 }
 
@@ -117,8 +118,8 @@ impl JobSvd {
         }
     }
 
-    pub fn as_ptr(&self) -> *const libc::c_char {
-        self as *const JobSvd as *const libc::c_char
+    pub fn as_ptr(&self) -> *const c_char {
+        self as *const JobSvd as *const c_char
     }
 }
 
@@ -133,7 +134,7 @@ pub enum Diag {
 }
 
 impl Diag {
-    pub fn as_ptr(&self) -> *const libc::c_char {
-        self as *const Diag as *const libc::c_char
+    pub fn as_ptr(&self) -> *const c_char {
+        self as *const Diag as *const c_char
     }
 }

--- a/lax/src/flags.rs
+++ b/lax/src/flags.rs
@@ -1,5 +1,5 @@
 //! Charactor flags, e.g. `'T'`, used in LAPACK API
-use std::ffi::c_char;
+use core::ffi::c_char;
 
 /// Upper/Lower specification for seveal usages
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]


### PR DESCRIPTION
this should fix issue #351 

I am willing to adapt to your preferences, but this works for me (tm)