### PR TITLE
Fix rcond_hilbert test

### DIFF
--- a/ndarray-linalg/tests/solve.rs
+++ b/ndarray-linalg/tests/solve.rs
@@ -254,7 +254,7 @@ fn rcond_hilbert() {
     macro_rules! rcond_hilbert {
         ($elem:ty, $rows:expr, $atol:expr) => {
             let a = Array2::<$elem>::from_shape_fn(($rows, $rows), |(i, j)| {
-                1. / (i as $elem + j as $elem - 1.)
+                1. / (i as $elem + j as $elem + 1.)
             });
             assert_aclose!(a.rcond().unwrap(), 0., $atol);
             assert_aclose!(a.rcond_into().unwrap(), 0., $atol);


### PR DESCRIPTION
The test `rcond_hilbert` was failing with a Lapack `return_code: -5`, since some elements of the matrix were `Inf` (when  `i+j-1=0`).

Test error:
```
---- rcond_hilbert stdout ----
thread 'rcond_hilbert' panicked at ndarray-linalg/tests/solve.rs:263:5:
called `Result::unwrap()` on an `Err` value: Lapack(LapackInvalidValue { return_code: -5 })
``` 