### PR TITLE
 Implement tridiagonal solve for Array1 right hand sides 

### DIFF
--- a/lax/src/eig.rs
+++ b/lax/src/eig.rs
@@ -8,7 +8,7 @@
 //! | sgeev | dgeev | cgeev | zgeev |
 //!
 
-use crate::{error::*, layout::MatrixLayout, *};
+use crate::{error::*, *};
 use cauchy::*;
 use num_traits::{ToPrimitive, Zero};
 

--- a/lax/src/eigh.rs
+++ b/lax/src/eigh.rs
@@ -8,7 +8,7 @@
 //! | ssyev | dsyev | cheev | zheev |
 
 use super::*;
-use crate::{error::*, layout::MatrixLayout};
+use crate::error::*;
 use cauchy::*;
 use num_traits::{ToPrimitive, Zero};
 

--- a/lax/src/eigh_generalized.rs
+++ b/lax/src/eigh_generalized.rs
@@ -9,7 +9,7 @@
 //!
 
 use super::*;
-use crate::{error::*, layout::MatrixLayout};
+use crate::error::*;
 use cauchy::*;
 use num_traits::{ToPrimitive, Zero};
 

--- a/lax/src/opnorm.rs
+++ b/lax/src/opnorm.rs
@@ -1,7 +1,6 @@
 //! Operator norm
 
-use super::{AsPtr, NormType};
-use crate::{layout::MatrixLayout, *};
+use crate::*;
 use cauchy::*;
 
 pub struct OperatorNormWork<T: Scalar> {

--- a/lax/src/qr.rs
+++ b/lax/src/qr.rs
@@ -1,6 +1,6 @@
 //! QR decomposition
 
-use crate::{error::*, layout::MatrixLayout, *};
+use crate::{error::*, *};
 use cauchy::*;
 use num_traits::{ToPrimitive, Zero};
 

--- a/lax/src/rcond.rs
+++ b/lax/src/rcond.rs
@@ -1,6 +1,6 @@
 //! Reciprocal conditional number
 
-use crate::{error::*, layout::MatrixLayout, *};
+use crate::{error::*, *};
 use cauchy::*;
 use num_traits::Zero;
 

--- a/lax/src/solve.rs
+++ b/lax/src/solve.rs
@@ -1,6 +1,6 @@
 //! Solve linear equations using LU-decomposition
 
-use crate::{error::*, layout::MatrixLayout, *};
+use crate::{error::*, *};
 use cauchy::*;
 use num_traits::{ToPrimitive, Zero};
 

--- a/lax/src/solveh.rs
+++ b/lax/src/solveh.rs
@@ -3,7 +3,7 @@
 //! [BK]: https://doi.org/10.2307/2005787
 //!
 
-use crate::{error::*, layout::MatrixLayout, *};
+use crate::{error::*, *};
 use cauchy::*;
 use num_traits::{ToPrimitive, Zero};
 

--- a/lax/src/svddc.rs
+++ b/lax/src/svddc.rs
@@ -8,7 +8,7 @@
 //! | sgesdd | dgesdd | cgesdd | zgesdd |
 //!
 
-use crate::{error::*, layout::MatrixLayout, *};
+use crate::{error::*, *};
 use cauchy::*;
 use num_traits::{ToPrimitive, Zero};
 

--- a/ndarray-linalg/src/tridiagonal.rs
+++ b/ndarray-linalg/src/tridiagonal.rs
@@ -109,437 +109,293 @@ pub trait SolveTridiagonalInplace<A: Scalar, D: Dimension> {
     ) -> Result<&'a mut ArrayBase<S, D>>;
 }
 
-impl<A> SolveTridiagonal<A, Ix2> for LUFactorizedTridiagonal<A>
-where
-    A: Scalar + Lapack,
-{
-    fn solve_tridiagonal<S: Data<Elem = A>>(&self, b: &ArrayBase<S, Ix2>) -> Result<Array<A, Ix2>> {
-        let mut b = replicate(b);
-        self.solve_tridiagonal_inplace(&mut b)?;
-        Ok(b)
+macro_rules! impl_traits { ($dim: ident, $layout: ident) => {
+    impl<A> SolveTridiagonal<A, $dim> for LUFactorizedTridiagonal<A>
+    where
+        A: Scalar + Lapack,
+    {
+        fn solve_tridiagonal<S: Data<Elem = A>>(
+            &self,
+            b: &ArrayBase<S, $dim>
+        ) -> Result<Array<A, $dim>> {
+            let mut b = replicate(b);
+            self.solve_tridiagonal_inplace(&mut b)?;
+            Ok(b)
+        }
+        fn solve_tridiagonal_into<S: DataMut<Elem = A>>(
+            &self,
+            mut b: ArrayBase<S, $dim>,
+        ) -> Result<ArrayBase<S, $dim>> {
+            self.solve_tridiagonal_inplace(&mut b)?;
+            Ok(b)
+        }
+        fn solve_t_tridiagonal<S: Data<Elem = A>>(
+            &self,
+            b: &ArrayBase<S, $dim>,
+        ) -> Result<Array<A, $dim>> {
+            let mut b = replicate(b);
+            self.solve_t_tridiagonal_inplace(&mut b)?;
+            Ok(b)
+        }
+        fn solve_t_tridiagonal_into<S: DataMut<Elem = A>>(
+            &self,
+            mut b: ArrayBase<S, $dim>,
+        ) -> Result<ArrayBase<S, $dim>> {
+            self.solve_t_tridiagonal_inplace(&mut b)?;
+            Ok(b)
+        }
+        fn solve_h_tridiagonal<S: Data<Elem = A>>(
+            &self,
+            b: &ArrayBase<S, $dim>,
+        ) -> Result<Array<A, $dim>> {
+            let mut b = replicate(b);
+            self.solve_h_tridiagonal_inplace(&mut b)?;
+            Ok(b)
+        }
+        fn solve_h_tridiagonal_into<S: DataMut<Elem = A>>(
+            &self,
+            mut b: ArrayBase<S, $dim>,
+        ) -> Result<ArrayBase<S, $dim>> {
+            self.solve_h_tridiagonal_inplace(&mut b)?;
+            Ok(b)
+        }
     }
-    fn solve_tridiagonal_into<S: DataMut<Elem = A>>(
-        &self,
-        mut b: ArrayBase<S, Ix2>,
-    ) -> Result<ArrayBase<S, Ix2>> {
-        self.solve_tridiagonal_inplace(&mut b)?;
-        Ok(b)
-    }
-    fn solve_t_tridiagonal<S: Data<Elem = A>>(
-        &self,
-        b: &ArrayBase<S, Ix2>,
-    ) -> Result<Array<A, Ix2>> {
-        let mut b = replicate(b);
-        self.solve_t_tridiagonal_inplace(&mut b)?;
-        Ok(b)
-    }
-    fn solve_t_tridiagonal_into<S: DataMut<Elem = A>>(
-        &self,
-        mut b: ArrayBase<S, Ix2>,
-    ) -> Result<ArrayBase<S, Ix2>> {
-        self.solve_t_tridiagonal_inplace(&mut b)?;
-        Ok(b)
-    }
-    fn solve_h_tridiagonal<S: Data<Elem = A>>(
-        &self,
-        b: &ArrayBase<S, Ix2>,
-    ) -> Result<Array<A, Ix2>> {
-        let mut b = replicate(b);
-        self.solve_h_tridiagonal_inplace(&mut b)?;
-        Ok(b)
-    }
-    fn solve_h_tridiagonal_into<S: DataMut<Elem = A>>(
-        &self,
-        mut b: ArrayBase<S, Ix2>,
-    ) -> Result<ArrayBase<S, Ix2>> {
-        self.solve_h_tridiagonal_inplace(&mut b)?;
-        Ok(b)
-    }
-}
 
-impl<A> SolveTridiagonal<A, Ix2> for Tridiagonal<A>
-where
-    A: Scalar + Lapack,
-{
-    fn solve_tridiagonal<Sb: Data<Elem = A>>(
-        &self,
-        b: &ArrayBase<Sb, Ix2>,
-    ) -> Result<Array<A, Ix2>> {
-        let mut b = replicate(b);
-        self.solve_tridiagonal_inplace(&mut b)?;
-        Ok(b)
+    impl<A> SolveTridiagonal<A, $dim> for Tridiagonal<A>
+    where
+        A: Scalar + Lapack,
+    {
+        fn solve_tridiagonal<Sb: Data<Elem = A>>(
+            &self,
+            b: &ArrayBase<Sb, $dim>,
+        ) -> Result<Array<A, $dim>> {
+            let mut b = replicate(b);
+            self.solve_tridiagonal_inplace(&mut b)?;
+            Ok(b)
+        }
+        fn solve_tridiagonal_into<Sb: DataMut<Elem = A>>(
+            &self,
+            mut b: ArrayBase<Sb, $dim>,
+        ) -> Result<ArrayBase<Sb, $dim>> {
+            self.solve_tridiagonal_inplace(&mut b)?;
+            Ok(b)
+        }
+        fn solve_t_tridiagonal<Sb: Data<Elem = A>>(
+            &self,
+            b: &ArrayBase<Sb, $dim>,
+        ) -> Result<Array<A, $dim>> {
+            let mut b = replicate(b);
+            self.solve_t_tridiagonal_inplace(&mut b)?;
+            Ok(b)
+        }
+        fn solve_t_tridiagonal_into<Sb: DataMut<Elem = A>>(
+            &self,
+            mut b: ArrayBase<Sb, $dim>,
+        ) -> Result<ArrayBase<Sb, $dim>> {
+            self.solve_t_tridiagonal_inplace(&mut b)?;
+            Ok(b)
+        }
+        fn solve_h_tridiagonal<Sb: Data<Elem = A>>(
+            &self,
+            b: &ArrayBase<Sb, $dim>,
+        ) -> Result<Array<A, $dim>> {
+            let mut b = replicate(b);
+            self.solve_h_tridiagonal_inplace(&mut b)?;
+            Ok(b)
+        }
+        fn solve_h_tridiagonal_into<Sb: DataMut<Elem = A>>(
+            &self,
+            mut b: ArrayBase<Sb, $dim>,
+        ) -> Result<ArrayBase<Sb, $dim>> {
+            self.solve_h_tridiagonal_inplace(&mut b)?;
+            Ok(b)
+        }
     }
-    fn solve_tridiagonal_into<Sb: DataMut<Elem = A>>(
-        &self,
-        mut b: ArrayBase<Sb, Ix2>,
-    ) -> Result<ArrayBase<Sb, Ix2>> {
-        self.solve_tridiagonal_inplace(&mut b)?;
-        Ok(b)
-    }
-    fn solve_t_tridiagonal<Sb: Data<Elem = A>>(
-        &self,
-        b: &ArrayBase<Sb, Ix2>,
-    ) -> Result<Array<A, Ix2>> {
-        let mut b = replicate(b);
-        self.solve_t_tridiagonal_inplace(&mut b)?;
-        Ok(b)
-    }
-    fn solve_t_tridiagonal_into<Sb: DataMut<Elem = A>>(
-        &self,
-        mut b: ArrayBase<Sb, Ix2>,
-    ) -> Result<ArrayBase<Sb, Ix2>> {
-        self.solve_t_tridiagonal_inplace(&mut b)?;
-        Ok(b)
-    }
-    fn solve_h_tridiagonal<Sb: Data<Elem = A>>(
-        &self,
-        b: &ArrayBase<Sb, Ix2>,
-    ) -> Result<Array<A, Ix2>> {
-        let mut b = replicate(b);
-        self.solve_h_tridiagonal_inplace(&mut b)?;
-        Ok(b)
-    }
-    fn solve_h_tridiagonal_into<Sb: DataMut<Elem = A>>(
-        &self,
-        mut b: ArrayBase<Sb, Ix2>,
-    ) -> Result<ArrayBase<Sb, Ix2>> {
-        self.solve_h_tridiagonal_inplace(&mut b)?;
-        Ok(b)
-    }
-}
 
-impl<A, S> SolveTridiagonal<A, Ix2> for ArrayBase<S, Ix2>
-where
-    A: Scalar + Lapack,
-    S: Data<Elem = A>,
-{
-    fn solve_tridiagonal<Sb: Data<Elem = A>>(
-        &self,
-        b: &ArrayBase<Sb, Ix2>,
-    ) -> Result<Array<A, Ix2>> {
-        let mut b = replicate(b);
-        self.solve_tridiagonal_inplace(&mut b)?;
-        Ok(b)
+    impl<A, S> SolveTridiagonal<A, $dim> for ArrayBase<S, Ix2>
+    where
+        A: Scalar + Lapack,
+        S: Data<Elem = A>,
+    {
+        fn solve_tridiagonal<Sb: Data<Elem = A>>(
+            &self,
+            b: &ArrayBase<Sb, $dim>,
+        ) -> Result<Array<A, $dim>> {
+            let mut b = replicate(b);
+            self.solve_tridiagonal_inplace(&mut b)?;
+            Ok(b)
+        }
+        fn solve_tridiagonal_into<Sb: DataMut<Elem = A>>(
+            &self,
+            mut b: ArrayBase<Sb, $dim>,
+        ) -> Result<ArrayBase<Sb, $dim>> {
+            self.solve_tridiagonal_inplace(&mut b)?;
+            Ok(b)
+        }
+        fn solve_t_tridiagonal<Sb: Data<Elem = A>>(
+            &self,
+            b: &ArrayBase<Sb, $dim>,
+        ) -> Result<Array<A, $dim>> {
+            let mut b = replicate(b);
+            self.solve_t_tridiagonal_inplace(&mut b)?;
+            Ok(b)
+        }
+        fn solve_t_tridiagonal_into<Sb: DataMut<Elem = A>>(
+            &self,
+            mut b: ArrayBase<Sb, $dim>,
+        ) -> Result<ArrayBase<Sb, $dim>> {
+            self.solve_t_tridiagonal_inplace(&mut b)?;
+            Ok(b)
+        }
+        fn solve_h_tridiagonal<Sb: Data<Elem = A>>(
+            &self,
+            b: &ArrayBase<Sb, $dim>,
+        ) -> Result<Array<A, $dim>> {
+            let mut b = replicate(b);
+            self.solve_h_tridiagonal_inplace(&mut b)?;
+            Ok(b)
+        }
+        fn solve_h_tridiagonal_into<Sb: DataMut<Elem = A>>(
+            &self,
+            mut b: ArrayBase<Sb, $dim>,
+        ) -> Result<ArrayBase<Sb, $dim>> {
+            self.solve_h_tridiagonal_inplace(&mut b)?;
+            Ok(b)
+        }
     }
-    fn solve_tridiagonal_into<Sb: DataMut<Elem = A>>(
-        &self,
-        mut b: ArrayBase<Sb, Ix2>,
-    ) -> Result<ArrayBase<Sb, Ix2>> {
-        self.solve_tridiagonal_inplace(&mut b)?;
-        Ok(b)
-    }
-    fn solve_t_tridiagonal<Sb: Data<Elem = A>>(
-        &self,
-        b: &ArrayBase<Sb, Ix2>,
-    ) -> Result<Array<A, Ix2>> {
-        let mut b = replicate(b);
-        self.solve_t_tridiagonal_inplace(&mut b)?;
-        Ok(b)
-    }
-    fn solve_t_tridiagonal_into<Sb: DataMut<Elem = A>>(
-        &self,
-        mut b: ArrayBase<Sb, Ix2>,
-    ) -> Result<ArrayBase<Sb, Ix2>> {
-        self.solve_t_tridiagonal_inplace(&mut b)?;
-        Ok(b)
-    }
-    fn solve_h_tridiagonal<Sb: Data<Elem = A>>(
-        &self,
-        b: &ArrayBase<Sb, Ix2>,
-    ) -> Result<Array<A, Ix2>> {
-        let mut b = replicate(b);
-        self.solve_h_tridiagonal_inplace(&mut b)?;
-        Ok(b)
-    }
-    fn solve_h_tridiagonal_into<Sb: DataMut<Elem = A>>(
-        &self,
-        mut b: ArrayBase<Sb, Ix2>,
-    ) -> Result<ArrayBase<Sb, Ix2>> {
-        self.solve_h_tridiagonal_inplace(&mut b)?;
-        Ok(b)
-    }
-}
 
-impl<A> SolveTridiagonalInplace<A, Ix2> for LUFactorizedTridiagonal<A>
-where
-    A: Scalar + Lapack,
-{
-    fn solve_tridiagonal_inplace<'a, Sb>(
-        &self,
-        rhs: &'a mut ArrayBase<Sb, Ix2>,
-    ) -> Result<&'a mut ArrayBase<Sb, Ix2>>
+    impl<A> SolveTridiagonalInplace<A, $dim> for LUFactorizedTridiagonal<A>
     where
-        Sb: DataMut<Elem = A>,
+        A: Scalar + Lapack,
     {
-        A::solve_tridiagonal(
-            self,
-            rhs.layout()?,
-            Transpose::No,
-            rhs.as_slice_mut().unwrap(),
-        )?;
-        Ok(rhs)
+        fn solve_tridiagonal_inplace<'a, Sb>(
+            &self,
+            rhs: &'a mut ArrayBase<Sb, $dim>,
+        ) -> Result<&'a mut ArrayBase<Sb, $dim>>
+        where
+            Sb: DataMut<Elem = A>,
+        {
+            A::solve_tridiagonal(
+                self,
+                $layout!(rhs),
+                Transpose::No,
+                rhs.as_slice_mut().unwrap(),
+            )?;
+            Ok(rhs)
+        }
+        fn solve_t_tridiagonal_inplace<'a, Sb>(
+            &self,
+            rhs: &'a mut ArrayBase<Sb, $dim>,
+        ) -> Result<&'a mut ArrayBase<Sb, $dim>>
+        where
+            Sb: DataMut<Elem = A>,
+        {
+            A::solve_tridiagonal(
+                self,
+                $layout!(rhs),
+                Transpose::Transpose,
+                rhs.as_slice_mut().unwrap(),
+            )?;
+            Ok(rhs)
+        }
+        fn solve_h_tridiagonal_inplace<'a, Sb>(
+            &self,
+            rhs: &'a mut ArrayBase<Sb, $dim>,
+        ) -> Result<&'a mut ArrayBase<Sb, $dim>>
+        where
+            Sb: DataMut<Elem = A>,
+        {
+            A::solve_tridiagonal(
+                self,
+                $layout!(rhs),
+                Transpose::Hermite,
+                rhs.as_slice_mut().unwrap(),
+            )?;
+            Ok(rhs)
+        }
     }
-    fn solve_t_tridiagonal_inplace<'a, Sb>(
-        &self,
-        rhs: &'a mut ArrayBase<Sb, Ix2>,
-    ) -> Result<&'a mut ArrayBase<Sb, Ix2>>
-    where
-        Sb: DataMut<Elem = A>,
-    {
-        A::solve_tridiagonal(
-            self,
-            rhs.layout()?,
-            Transpose::Transpose,
-            rhs.as_slice_mut().unwrap(),
-        )?;
-        Ok(rhs)
-    }
-    fn solve_h_tridiagonal_inplace<'a, Sb>(
-        &self,
-        rhs: &'a mut ArrayBase<Sb, Ix2>,
-    ) -> Result<&'a mut ArrayBase<Sb, Ix2>>
-    where
-        Sb: DataMut<Elem = A>,
-    {
-        A::solve_tridiagonal(
-            self,
-            rhs.layout()?,
-            Transpose::Hermite,
-            rhs.as_slice_mut().unwrap(),
-        )?;
-        Ok(rhs)
-    }
-}
 
-impl<A> SolveTridiagonalInplace<A, Ix2> for Tridiagonal<A>
-where
-    A: Scalar + Lapack,
-{
-    fn solve_tridiagonal_inplace<'a, Sb>(
-        &self,
-        rhs: &'a mut ArrayBase<Sb, Ix2>,
-    ) -> Result<&'a mut ArrayBase<Sb, Ix2>>
+    impl<A> SolveTridiagonalInplace<A, $dim> for Tridiagonal<A>
     where
-        Sb: DataMut<Elem = A>,
+        A: Scalar + Lapack,
     {
-        let f = self.factorize_tridiagonal()?;
-        f.solve_tridiagonal_inplace(rhs)
+        fn solve_tridiagonal_inplace<'a, Sb>(
+            &self,
+            rhs: &'a mut ArrayBase<Sb, $dim>,
+        ) -> Result<&'a mut ArrayBase<Sb, $dim>>
+        where
+            Sb: DataMut<Elem = A>,
+        {
+            let f = self.factorize_tridiagonal()?;
+            f.solve_tridiagonal_inplace(rhs)
+        }
+        fn solve_t_tridiagonal_inplace<'a, Sb>(
+            &self,
+            rhs: &'a mut ArrayBase<Sb, $dim>,
+        ) -> Result<&'a mut ArrayBase<Sb, $dim>>
+        where
+            Sb: DataMut<Elem = A>,
+        {
+            let f = self.factorize_tridiagonal()?;
+            f.solve_t_tridiagonal_inplace(rhs)
+        }
+        fn solve_h_tridiagonal_inplace<'a, Sb>(
+            &self,
+            rhs: &'a mut ArrayBase<Sb, $dim>,
+        ) -> Result<&'a mut ArrayBase<Sb, $dim>>
+        where
+            Sb: DataMut<Elem = A>,
+        {
+            let f = self.factorize_tridiagonal()?;
+            f.solve_h_tridiagonal_inplace(rhs)
+        }
     }
-    fn solve_t_tridiagonal_inplace<'a, Sb>(
-        &self,
-        rhs: &'a mut ArrayBase<Sb, Ix2>,
-    ) -> Result<&'a mut ArrayBase<Sb, Ix2>>
-    where
-        Sb: DataMut<Elem = A>,
-    {
-        let f = self.factorize_tridiagonal()?;
-        f.solve_t_tridiagonal_inplace(rhs)
-    }
-    fn solve_h_tridiagonal_inplace<'a, Sb>(
-        &self,
-        rhs: &'a mut ArrayBase<Sb, Ix2>,
-    ) -> Result<&'a mut ArrayBase<Sb, Ix2>>
-    where
-        Sb: DataMut<Elem = A>,
-    {
-        let f = self.factorize_tridiagonal()?;
-        f.solve_h_tridiagonal_inplace(rhs)
-    }
-}
 
-impl<A, S> SolveTridiagonalInplace<A, Ix2> for ArrayBase<S, Ix2>
-where
-    A: Scalar + Lapack,
-    S: Data<Elem = A>,
-{
-    fn solve_tridiagonal_inplace<'a, Sb>(
-        &self,
-        rhs: &'a mut ArrayBase<Sb, Ix2>,
-    ) -> Result<&'a mut ArrayBase<Sb, Ix2>>
+    impl<A, S> SolveTridiagonalInplace<A, $dim> for ArrayBase<S, Ix2>
     where
-        Sb: DataMut<Elem = A>,
+        A: Scalar + Lapack,
+        S: Data<Elem = A>,
     {
-        let f = self.factorize_tridiagonal()?;
-        f.solve_tridiagonal_inplace(rhs)
+        fn solve_tridiagonal_inplace<'a, Sb>(
+            &self,
+            rhs: &'a mut ArrayBase<Sb, $dim>,
+        ) -> Result<&'a mut ArrayBase<Sb, $dim>>
+        where
+            Sb: DataMut<Elem = A>,
+        {
+            let f = self.factorize_tridiagonal()?;
+            f.solve_tridiagonal_inplace(rhs)
+        }
+        fn solve_t_tridiagonal_inplace<'a, Sb>(
+            &self,
+            rhs: &'a mut ArrayBase<Sb, $dim>,
+        ) -> Result<&'a mut ArrayBase<Sb, $dim>>
+        where
+            Sb: DataMut<Elem = A>,
+        {
+            let f = self.factorize_tridiagonal()?;
+            f.solve_t_tridiagonal_inplace(rhs)
+        }
+        fn solve_h_tridiagonal_inplace<'a, Sb>(
+            &self,
+            rhs: &'a mut ArrayBase<Sb, $dim>,
+        ) -> Result<&'a mut ArrayBase<Sb, $dim>>
+        where
+            Sb: DataMut<Elem = A>,
+        {
+            let f = self.factorize_tridiagonal()?;
+            f.solve_h_tridiagonal_inplace(rhs)
+        }
     }
-    fn solve_t_tridiagonal_inplace<'a, Sb>(
-        &self,
-        rhs: &'a mut ArrayBase<Sb, Ix2>,
-    ) -> Result<&'a mut ArrayBase<Sb, Ix2>>
-    where
-        Sb: DataMut<Elem = A>,
-    {
-        let f = self.factorize_tridiagonal()?;
-        f.solve_t_tridiagonal_inplace(rhs)
-    }
-    fn solve_h_tridiagonal_inplace<'a, Sb>(
-        &self,
-        rhs: &'a mut ArrayBase<Sb, Ix2>,
-    ) -> Result<&'a mut ArrayBase<Sb, Ix2>>
-    where
-        Sb: DataMut<Elem = A>,
-    {
-        let f = self.factorize_tridiagonal()?;
-        f.solve_h_tridiagonal_inplace(rhs)
-    }
-}
+}}
 
-impl<A> SolveTridiagonal<A, Ix1> for LUFactorizedTridiagonal<A>
-where
-    A: Scalar + Lapack,
-{
-    fn solve_tridiagonal<S: Data<Elem = A>>(&self, b: &ArrayBase<S, Ix1>) -> Result<Array<A, Ix1>> {
-        let b = b.to_owned();
-        self.solve_tridiagonal_into(b)
-    }
-    fn solve_tridiagonal_into<S: DataMut<Elem = A>>(
-        &self,
-        b: ArrayBase<S, Ix1>,
-    ) -> Result<ArrayBase<S, Ix1>> {
-        let b = into_col(b);
-        let b = self.solve_tridiagonal_into(b)?;
-        Ok(flatten(b))
-    }
-    fn solve_t_tridiagonal<S: Data<Elem = A>>(
-        &self,
-        b: &ArrayBase<S, Ix1>,
-    ) -> Result<Array<A, Ix1>> {
-        let b = b.to_owned();
-        self.solve_t_tridiagonal_into(b)
-    }
-    fn solve_t_tridiagonal_into<S: DataMut<Elem = A>>(
-        &self,
-        b: ArrayBase<S, Ix1>,
-    ) -> Result<ArrayBase<S, Ix1>> {
-        let b = into_col(b);
-        let b = self.solve_t_tridiagonal_into(b)?;
-        Ok(flatten(b))
-    }
-    fn solve_h_tridiagonal<S: Data<Elem = A>>(
-        &self,
-        b: &ArrayBase<S, Ix1>,
-    ) -> Result<Array<A, Ix1>> {
-        let b = b.to_owned();
-        self.solve_h_tridiagonal_into(b)
-    }
-    fn solve_h_tridiagonal_into<S: DataMut<Elem = A>>(
-        &self,
-        b: ArrayBase<S, Ix1>,
-    ) -> Result<ArrayBase<S, Ix1>> {
-        let b = into_col(b);
-        let b = self.solve_h_tridiagonal_into(b)?;
-        Ok(flatten(b))
-    }
-}
+macro_rules! layoutIx1 { ($rhs: ident) => {
+    MatrixLayout::C { row: $rhs.dim() as i32, lda: 1 }
+}}
+impl_traits!(Ix1, layoutIx1);
 
-impl<A> SolveTridiagonal<A, Ix1> for Tridiagonal<A>
-where
-    A: Scalar + Lapack,
-{
-    fn solve_tridiagonal<Sb: Data<Elem = A>>(
-        &self,
-        b: &ArrayBase<Sb, Ix1>,
-    ) -> Result<Array<A, Ix1>> {
-        let b = b.to_owned();
-        self.solve_tridiagonal_into(b)
-    }
-    fn solve_tridiagonal_into<Sb: DataMut<Elem = A>>(
-        &self,
-        b: ArrayBase<Sb, Ix1>,
-    ) -> Result<ArrayBase<Sb, Ix1>> {
-        let b = into_col(b);
-        let f = self.factorize_tridiagonal()?;
-        let b = f.solve_tridiagonal_into(b)?;
-        Ok(flatten(b))
-    }
-    fn solve_t_tridiagonal<Sb: Data<Elem = A>>(
-        &self,
-        b: &ArrayBase<Sb, Ix1>,
-    ) -> Result<Array<A, Ix1>> {
-        let b = b.to_owned();
-        self.solve_t_tridiagonal_into(b)
-    }
-    fn solve_t_tridiagonal_into<Sb: DataMut<Elem = A>>(
-        &self,
-        b: ArrayBase<Sb, Ix1>,
-    ) -> Result<ArrayBase<Sb, Ix1>> {
-        let b = into_col(b);
-        let f = self.factorize_tridiagonal()?;
-        let b = f.solve_t_tridiagonal_into(b)?;
-        Ok(flatten(b))
-    }
-    fn solve_h_tridiagonal<Sb: Data<Elem = A>>(
-        &self,
-        b: &ArrayBase<Sb, Ix1>,
-    ) -> Result<Array<A, Ix1>> {
-        let b = b.to_owned();
-        self.solve_h_tridiagonal_into(b)
-    }
-    fn solve_h_tridiagonal_into<Sb: DataMut<Elem = A>>(
-        &self,
-        b: ArrayBase<Sb, Ix1>,
-    ) -> Result<ArrayBase<Sb, Ix1>> {
-        let b = into_col(b);
-        let f = self.factorize_tridiagonal()?;
-        let b = f.solve_h_tridiagonal_into(b)?;
-        Ok(flatten(b))
-    }
-}
-
-impl<A, S> SolveTridiagonal<A, Ix1> for ArrayBase<S, Ix2>
-where
-    A: Scalar + Lapack,
-    S: Data<Elem = A>,
-{
-    fn solve_tridiagonal<Sb: Data<Elem = A>>(
-        &self,
-        b: &ArrayBase<Sb, Ix1>,
-    ) -> Result<Array<A, Ix1>> {
-        let b = b.to_owned();
-        self.solve_tridiagonal_into(b)
-    }
-    fn solve_tridiagonal_into<Sb: DataMut<Elem = A>>(
-        &self,
-        b: ArrayBase<Sb, Ix1>,
-    ) -> Result<ArrayBase<Sb, Ix1>> {
-        let b = into_col(b);
-        let f = self.factorize_tridiagonal()?;
-        let b = f.solve_tridiagonal_into(b)?;
-        Ok(flatten(b))
-    }
-    fn solve_t_tridiagonal<Sb: Data<Elem = A>>(
-        &self,
-        b: &ArrayBase<Sb, Ix1>,
-    ) -> Result<Array<A, Ix1>> {
-        let b = b.to_owned();
-        self.solve_t_tridiagonal_into(b)
-    }
-    fn solve_t_tridiagonal_into<Sb: DataMut<Elem = A>>(
-        &self,
-        b: ArrayBase<Sb, Ix1>,
-    ) -> Result<ArrayBase<Sb, Ix1>> {
-        let b = into_col(b);
-        let f = self.factorize_tridiagonal()?;
-        let b = f.solve_t_tridiagonal_into(b)?;
-        Ok(flatten(b))
-    }
-    fn solve_h_tridiagonal<Sb: Data<Elem = A>>(
-        &self,
-        b: &ArrayBase<Sb, Ix1>,
-    ) -> Result<Array<A, Ix1>> {
-        let b = b.to_owned();
-        self.solve_h_tridiagonal_into(b)
-    }
-    fn solve_h_tridiagonal_into<Sb: DataMut<Elem = A>>(
-        &self,
-        b: ArrayBase<Sb, Ix1>,
-    ) -> Result<ArrayBase<Sb, Ix1>> {
-        let b = into_col(b);
-        let f = self.factorize_tridiagonal()?;
-        let b = f.solve_h_tridiagonal_into(b)?;
-        Ok(flatten(b))
-    }
-}
+macro_rules! layoutIx2 { ($rhs: ident) => { $rhs.layout()? }}
+impl_traits!(Ix2, layoutIx2);
 
 /// An interface for computing LU factorizations of tridiagonal matrix refs.
 pub trait FactorizeTridiagonal<A: Scalar> {

--- a/ndarray-linalg/tests/layout.rs
+++ b/ndarray-linalg/tests/layout.rs
@@ -1,5 +1,4 @@
 use ndarray::*;
-use ndarray_linalg::layout::MatrixLayout;
 use ndarray_linalg::*;
 
 #[test]

--- a/ndarray-linalg/tests/tridiagonal.rs
+++ b/ndarray-linalg/tests/tridiagonal.rs
@@ -43,6 +43,35 @@ fn opnorm_tridiagonal() {
 }
 
 #[test]
+fn solve_tridiagonal_Ix2_Ix1_f64() {
+    let a: Array2<f64> = arr2(&[
+        [3.0, 2.1, 0.0, 0.0, 0.0],
+        [3.4, 2.3, -1.0, 0.0, 0.0],
+        [0.0, 3.6, -5.0, 1.9, 0.0],
+        [0.0, 0.0, 7.0, -0.9, 8.0],
+        [0.0, 0.0, 0.0, -6.0, 7.1],
+    ]);
+    let mut b: Array1<f64> = arr1(&[ 2.7, -0.5, 2.6,  0.6,  2.7 ]);
+    let x: Array1<f64> = arr1(&[-4.0,  7.0, 3.0, -4.0, -3.0 ]);
+    a.solve_tridiagonal_inplace(&mut b).unwrap();
+    assert_close_l2!(&x, &b, 1e-7);
+}
+
+#[test]
+fn solve_tridiagonal_Ix1_f64() {
+    let a: Tridiagonal<f64> = Tridiagonal {
+        l: MatrixLayout::C { row: 5, lda: 5 },
+        du: vec![ 2.1, -1.0,  1.9,  8.0 ],
+        d:  vec![ 3.0,  2.3, -5.0, -0.9, 7.1 ],
+        dl: vec![ 3.4,  3.6,  7.0, -6.0 ],
+    };
+    let mut b: Array1<f64> = arr1(&[ 2.7, -0.5, 2.6,  0.6,  2.7 ]);
+    let x: Array1<f64> = arr1(&[-4.0,  7.0, 3.0, -4.0, -3.0 ]);
+    a.solve_tridiagonal_inplace(&mut b).unwrap();
+    assert_close_l2!(&x, &b, 1e-7);
+}
+
+#[test]
 fn solve_tridiagonal_f64() {
     // https://www.nag-j.co.jp/lapack/dgttrs.htm
     let a: Array2<f64> = arr2(&[


### PR DESCRIPTION
When one only has one RHS to solve for, it is natural to represent it as an `Array1` (also because it is used in other contextes).  This PR implements the tridiagonal solve functions for `Ix1` dimensions.