### PR TITLE
Upgrade ndarray dependency to 0.16.1

### DIFF
--- a/ndarray-linalg/Cargo.toml
+++ b/ndarray-linalg/Cargo.toml
@@ -37,7 +37,7 @@ rand = "0.8.3"
 thiserror = "1.0.24"
 
 [dependencies.ndarray]
-version = "0.15.2"
+version = "0.16.1"
 features = ["blas", "approx", "std"]
 default-features = false
 
@@ -50,7 +50,7 @@ default-features = false
 paste = "1.0.5"
 criterion = "0.3.4"
 # Keep the same version as ndarray's dependency!
-approx = { version = "0.4.0", features = ["num-complex"] }
+approx = { version = "0.5.0", features = ["num-complex"] }
 rand_pcg = "0.3.1"
 
 [[bench]]

--- a/ndarray-linalg/tests/det.rs
+++ b/ndarray-linalg/tests/det.rs
@@ -94,7 +94,7 @@ fn det_zero_nonsquare() {
             assert!(a.sln_det_into().is_err());
         };
     }
-    for &shape in &[(1, 2).into_shape(), (1, 2).f()] {
+    for &shape in &[(1, 2).into_shape_with_order(), (1, 2).f()] {
         det_zero_nonsquare!(f64, shape);
         det_zero_nonsquare!(f32, shape);
         det_zero_nonsquare!(c64, shape);
@@ -186,7 +186,7 @@ fn det_nonsquare() {
         };
     }
     for &dims in &[(1, 0), (1, 2), (2, 1), (2, 3)] {
-        for &shape in &[dims.into_shape(), dims.f()] {
+        for &shape in &[dims.into_shape_with_order(), dims.f()] {
             det_nonsquare!(f64, shape);
             det_nonsquare!(f32, shape);
             det_nonsquare!(c64, shape);

--- a/ndarray-linalg/tests/deth.rs
+++ b/ndarray-linalg/tests/deth.rs
@@ -60,7 +60,7 @@ fn deth_zero_nonsquare() {
             assert!(a.sln_deth_into().is_err());
         };
     }
-    for &shape in &[(1, 2).into_shape(), (1, 2).f()] {
+    for &shape in &[(1, 2).into_shape_with_order(), (1, 2).f()] {
         deth_zero_nonsquare!(f64, shape);
         deth_zero_nonsquare!(f32, shape);
         deth_zero_nonsquare!(c64, shape);
@@ -138,7 +138,7 @@ fn deth_nonsquare() {
         };
     }
     for &dims in &[(1, 0), (1, 2), (2, 1), (2, 3)] {
-        for &shape in &[dims.into_shape(), dims.f()] {
+        for &shape in &[dims.into_shape_with_order(), dims.f()] {
             deth_nonsquare!(f64, shape);
             deth_nonsquare!(f32, shape);
             deth_nonsquare!(c64, shape);


### PR DESCRIPTION
I upgraded the ndarray dependency from version 0.15.6 to version 0.16.1, and upgraded approx from 0.4 to 0.5