### PR TITLE
Does absolute minimum to bump ndarray to 0.16.1

### DIFF
--- a/ndarray-linalg/Cargo.toml
+++ b/ndarray-linalg/Cargo.toml
@@ -37,7 +37,7 @@ rand = "0.8.3"
 thiserror = "1.0.24"
 
 [dependencies.ndarray]
-version = "0.15.2"
+version = "0.16.1"
 features = ["blas", "approx", "std"]
 default-features = false
 

--- a/ndarray-linalg/src/convert.rs
+++ b/ndarray-linalg/src/convert.rs
@@ -97,14 +97,14 @@ where
 {
     // FIXME
     // https://github.com/bluss/rust-ndarray/issues/325
-    let strides: Vec<isize> = a.strides().to_vec();
+    let strides: Vec<isize> = ArrayBase::strides(&a).to_vec();
     let new = if a.is_standard_layout() {
-        ArrayBase::from_shape_vec(a.dim(), a.into_raw_vec()).unwrap()
+        ArrayBase::from_shape_vec(a.dim(), a.into_raw_vec_and_offset().0).unwrap()
     } else {
-        ArrayBase::from_shape_vec(a.dim().f(), a.into_raw_vec()).unwrap()
+        ArrayBase::from_shape_vec(a.dim().f(), a.into_raw_vec_and_offset().0).unwrap()
     };
     assert_eq!(
-        new.strides(),
+        ArrayBase::strides(&new),
         strides.as_slice(),
         "Custom stride is not supported"
     );

--- a/ndarray-linalg/src/convert.rs
+++ b/ndarray-linalg/src/convert.rs
@@ -99,9 +99,9 @@ where
     // https://github.com/bluss/rust-ndarray/issues/325
     let strides: Vec<isize> = ArrayBase::strides(&a).to_vec();
     let new = if a.is_standard_layout() {
-        ArrayBase::from_shape_vec(a.dim(), a.into_raw_vec_and_offset().0).unwrap()
+        ArrayBase::from_shape_vec(a.dim(), a.into_raw_vec()).unwrap()
     } else {
-        ArrayBase::from_shape_vec(a.dim().f(), a.into_raw_vec_and_offset().0).unwrap()
+        ArrayBase::from_shape_vec(a.dim().f(), a.into_raw_vec()).unwrap()
     };
     assert_eq!(
         ArrayBase::strides(&new),

--- a/ndarray-linalg/tests/det.rs
+++ b/ndarray-linalg/tests/det.rs
@@ -94,7 +94,7 @@ fn det_zero_nonsquare() {
             assert!(a.sln_det_into().is_err());
         };
     }
-    for &shape in &[(1, 2).into_shape(), (1, 2).f()] {
+    for &shape in &[(1, 2).into_shape_with_order(), (1, 2).f()] {
         det_zero_nonsquare!(f64, shape);
         det_zero_nonsquare!(f32, shape);
         det_zero_nonsquare!(c64, shape);
@@ -186,7 +186,7 @@ fn det_nonsquare() {
         };
     }
     for &dims in &[(1, 0), (1, 2), (2, 1), (2, 3)] {
-        for &shape in &[dims.into_shape(), dims.f()] {
+        for &shape in &[dims.into_shape_with_order(), dims.f()] {
             det_nonsquare!(f64, shape);
             det_nonsquare!(f32, shape);
             det_nonsquare!(c64, shape);

--- a/ndarray-linalg/tests/deth.rs
+++ b/ndarray-linalg/tests/deth.rs
@@ -60,7 +60,7 @@ fn deth_zero_nonsquare() {
             assert!(a.sln_deth_into().is_err());
         };
     }
-    for &shape in &[(1, 2).into_shape(), (1, 2).f()] {
+    for &shape in &[(1, 2).into_shape_with_order(), (1, 2).f()] {
         deth_zero_nonsquare!(f64, shape);
         deth_zero_nonsquare!(f32, shape);
         deth_zero_nonsquare!(c64, shape);
@@ -138,7 +138,7 @@ fn deth_nonsquare() {
         };
     }
     for &dims in &[(1, 0), (1, 2), (2, 1), (2, 3)] {
-        for &shape in &[dims.into_shape(), dims.f()] {
+        for &shape in &[dims.into_shape_with_order(), dims.f()] {
             deth_nonsquare!(f64, shape);
             deth_nonsquare!(f32, shape);
             deth_nonsquare!(c64, shape);

--- a/ndarray-linalg/tests/inv.rs
+++ b/ndarray-linalg/tests/inv.rs
@@ -106,7 +106,7 @@ fn inv_into_random_complex() {
 #[should_panic]
 fn inv_error() {
     // do not have inverse
-    let a = Array::<f64, _>::zeros(9).into_shape((3, 3)).unwrap();
+    let a = Array::<f64, _>::zeros((3, 3));
     let a_inv = a.inv().unwrap();
     println!("{:?}", a_inv);
 }

--- a/ndarray-linalg/tests/solve.rs
+++ b/ndarray-linalg/tests/solve.rs
@@ -256,7 +256,6 @@ fn rcond_hilbert() {
             let a = Array2::<$elem>::from_shape_fn(($rows, $rows), |(i, j)| {
                 1. / (i as $elem + j as $elem - 1.)
             });
-            println!("{:?}", a);
             assert_aclose!(a.rcond().unwrap(), 0., $atol);
             assert_aclose!(a.rcond_into().unwrap(), 0., $atol);
         };

--- a/ndarray-linalg/tests/solve.rs
+++ b/ndarray-linalg/tests/solve.rs
@@ -256,6 +256,7 @@ fn rcond_hilbert() {
             let a = Array2::<$elem>::from_shape_fn(($rows, $rows), |(i, j)| {
                 1. / (i as $elem + j as $elem - 1.)
             });
+            println!("{:?}", a);
             assert_aclose!(a.rcond().unwrap(), 0., $atol);
             assert_aclose!(a.rcond_into().unwrap(), 0., $atol);
         };


### PR DESCRIPTION
Only failing test (rcond_hilbert) was failing previously. As I said, absolute minimum.