### PR TITLE
Avoid hardcoded assumed pointer types

### DIFF
--- a/lax/src/flags.rs
+++ b/lax/src/flags.rs
@@ -1,4 +1,5 @@
 //! Charactor flags, e.g. `'T'`, used in LAPACK API
+use core::ffi::c_char;
 
 /// Upper/Lower specification for seveal usages
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -17,8 +18,8 @@ impl UPLO {
     }
 
     /// To use Fortran LAPACK API in lapack-sys crate
-    pub fn as_ptr(&self) -> *const i8 {
-        self as *const UPLO as *const i8
+    pub fn as_ptr(&self) -> *const c_char {
+        self as *const UPLO as *const c_char
     }
 }
 
@@ -32,8 +33,8 @@ pub enum Transpose {
 
 impl Transpose {
     /// To use Fortran LAPACK API in lapack-sys crate
-    pub fn as_ptr(&self) -> *const i8 {
-        self as *const Transpose as *const i8
+    pub fn as_ptr(&self) -> *const c_char {
+        self as *const Transpose as *const c_char
     }
 }
 
@@ -55,8 +56,8 @@ impl NormType {
     }
 
     /// To use Fortran LAPACK API in lapack-sys crate
-    pub fn as_ptr(&self) -> *const i8 {
-        self as *const NormType as *const i8
+    pub fn as_ptr(&self) -> *const c_char {
+        self as *const NormType as *const c_char
     }
 }
 
@@ -87,8 +88,8 @@ impl JobEv {
     }
 
     /// To use Fortran LAPACK API in lapack-sys crate
-    pub fn as_ptr(&self) -> *const i8 {
-        self as *const JobEv as *const i8
+    pub fn as_ptr(&self) -> *const c_char {
+        self as *const JobEv as *const c_char
     }
 }
 
@@ -117,8 +118,8 @@ impl JobSvd {
         }
     }
 
-    pub fn as_ptr(&self) -> *const i8 {
-        self as *const JobSvd as *const i8
+    pub fn as_ptr(&self) -> *const c_char {
+        self as *const JobSvd as *const c_char
     }
 }
 
@@ -133,7 +134,7 @@ pub enum Diag {
 }
 
 impl Diag {
-    pub fn as_ptr(&self) -> *const i8 {
-        self as *const Diag as *const i8
+    pub fn as_ptr(&self) -> *const c_char {
+        self as *const Diag as *const c_char
     }
 }


### PR DESCRIPTION
Depends on https://github.com/blas-lapack-rs/lapack-sys/pull/15

This replaces hardcoded platform-specific `char*` types with the opaque types from [`core::ffi`](https://doc.rust-lang.org/stable/core/ffi/type.c_char.html). This is necessary when cross-compiling.

I believe when interacting with C and Fortran, both `lax` and `lapack-sys` should not assume integer and pointer types. Current setup is biased towards x86_64 platform, for the most part due to a bug in `lapack-sys` (see https://github.com/blas-lapack-rs/lapack-sys/pull/15), and it could cause broken builds and undefined behavior on other platforms.

For example, cross compilation build could fail with:

```
error[E0308]: mismatched types
     --> /home/user/.cargo/registry/src/index.crates.io-6f17d22bba15001f/lax-0.16.0/src/cholesky.rs:30:26
      |
30    |                     $trf(uplo.as_ptr(), &n, AsPtr::as_mut_ptr(a), &n, &mut info);
      |                     ---- ^^^^^^^^^^^^^ expected `*const u8`, found `*const i8`
      |                     |
      |                     arguments to this function are incorrect
...
41    | impl_cholesky_!(c64, lapack_sys::zpotrf_);
      | ----------------------------------------- in this macro invocation
      |
      = note: expected raw pointer `*const u8`
                 found raw pointer `*const i8`
note: function defined here
     --> /workdir/.build/docker-aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/release/build/lapack-sys-5fad11066d38a1a6/out/bindings.rs:12886:12
```

Full build log for aarch64-unknown-linux-gnu:
[build.log.txt](https://github.com/user-attachments/files/17706011/build.log.txt)

In this PR I change `i8` to `core::ffi::c_char` - this, for example, [resolves](https://doc.rust-lang.org/stable/src/core/ffi/mod.rs.html#92-154) to `i8` on x86  and to `u8` on ARM, but is also universal for any platform rust supports, removing bias towards x86.