### PR TITLE
Add a feature to turn on/off blas backend

### DIFF
--- a/ndarray-linalg/Cargo.toml
+++ b/ndarray-linalg/Cargo.toml
@@ -13,7 +13,8 @@ readme        = "../README.md"
 categories    = ["algorithms", "science"]
 
 [features]
-default   = []
+default   = ["blas"]
+blas      = ["ndarray/blas"]
 
 netlib    = ["lax/netlib"]
 openblas  = ["lax/openblas"]
@@ -38,7 +39,7 @@ thiserror = "1.0.24"
 
 [dependencies.ndarray]
 version = "0.15.2"
-features = ["blas", "approx", "std"]
+features = ["approx", "std"]
 default-features = false
 
 [dependencies.lax]


### PR DESCRIPTION
ndarray by default turns off blas backend, but ndarray-linalg turns it on by default and there is no way to turn it off. This change adds a cargo feature to control it. It's a default feature, so users who don't want to use blas backend need `default-features = false` in their Cargo.toml.

This change allows us to use this crate on WebAssembly.