### PR TITLE
Update lax dependencies

### DIFF
--- a/lax/Cargo.toml
+++ b/lax/Cargo.toml
@@ -41,7 +41,7 @@ default-features = false
 optional = true
 
 [dependencies.netlib-src]
-version = "0.8.0"
+version = "0.9.0"
 optional = true
 features = ["cblas"]
 default-features = false

--- a/lax/Cargo.toml
+++ b/lax/Cargo.toml
@@ -32,7 +32,7 @@ intel-mkl-system = ["intel-mkl-src/mkl-dynamic-lp64-seq"]
 thiserror = "2.0.0"
 cauchy = "0.4.0"
 num-traits = "0.2.14"
-lapack-sys = "0.14.0"
+lapack-sys = "0.15.0"
 katexit = "0.1.2"
 
 [dependencies.intel-mkl-src]


### PR DESCRIPTION
In particular, Netlib 0.8 doesn't work with CMake 4.0, but 0.9 does.