### PR TITLE
release 0.18.0

### DIFF
--- a/lax/Cargo.toml
+++ b/lax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lax"
-version = "0.17.0"
+version = "0.18.0"
 authors = ["Toshiki Teramura <toshiki.teramura@gmail.com>"]
 edition = "2021"
 

--- a/ndarray-linalg/Cargo.toml
+++ b/ndarray-linalg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "ndarray-linalg"
-version = "0.17.0"
+version = "0.18.0"
 authors = ["Toshiki Teramura <toshiki.teramura@gmail.com>"]
 edition = "2021"
 
@@ -52,7 +52,7 @@ features = ["approx", "std"]
 default-features = false
 
 [dependencies.lax]
-version = "0.17.0"
+version = "0.18.0"
 path = "../lax"
 default-features = false
 


### PR DESCRIPTION
## What's Changed
### Breaking Change
* Bump ndarray to 0.17 by @Dirreke in https://github.com/rust-ndarray/ndarray-linalg/pull/407

### New features
* Implement generalized eigenvalue solver for general square matrices (LAPACK's ?ggev) by @bangconghuynh in https://github.com/rust-ndarray/ndarray-linalg/pull/403
* Update features to match intel-mkl-src 8.1 by @Dirreke in https://github.com/rust-ndarray/ndarray-linalg/pull/409

### Bug fixes
* fix test by @Dirreke in https://github.com/rust-ndarray/ndarray-linalg/pull/399
* Update lax dependencies by @berquist in https://github.com/rust-ndarray/ndarray-linalg/pull/395

### Others
* fix: Add Helping Verb to README by @evolvedmicrobe in https://github.com/rust-ndarray/ndarray-linalg/pull/405
* Update edition to 2021 by @Dirreke in https://github.com/rust-ndarray/ndarray-linalg/pull/408
