### PR TITLE
Bump openblas-src and add rustls feature flag

### DIFF
--- a/lax/Cargo.toml
+++ b/lax/Cargo.toml
@@ -56,7 +56,7 @@ features = ["cblas"]
 default-features = false
 
 [dependencies.openblas-src]
-version = "0.10.4"
+version = "0.10.16"
 optional = true
 default-features = false
-features = ["cblas"]
+features = ["cblas", "rustls"]


### PR DESCRIPTION
openblas-src v0.10.16 requires either the rustls feature flag or the native-tls feature flag to be specified. lax was passing neither. This bumps the openblas-src version used by lax to v0.10.16 and passes the rustls feature flag.